### PR TITLE
fix: resolve Configure Push Reminders button error (v1.3.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Bolt to GitHub is a Chrome Extension (Manifest v3) that automatically captures ZIP file downloads from bolt.new, extracts them, and pushes contents to GitHub repositories. Built with Svelte v4.2.x, TypeScript v5.6.x, and TailwindCSS.
 
-**Current Version**: v1.3.2  
+**Current Version**: v1.3.3  
 **Repository**: mamertofabian/bolt-to-github  
 **Package Manager**: pnpm (required)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bolt to GitHub",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Automatically process your Bolt project zip files and upload them to your GitHub repository.",
   "icons": {
     "16": "assets/icons/icon16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bolt-to-github",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/utils/upgradeModal.ts
+++ b/src/lib/utils/upgradeModal.ts
@@ -12,7 +12,22 @@ export interface UpgradeModalData {
  * Get upgrade modal configuration by type
  */
 export function getUpgradeModalConfig(type: UpgradeModalType): UpgradeModalData {
-  return UPGRADE_MODAL_CONFIGS[type];
+  const config = UPGRADE_MODAL_CONFIGS[type];
+  if (!config) {
+    console.error(
+      'Invalid upgrade modal type:',
+      type,
+      'Available types:',
+      Object.keys(UPGRADE_MODAL_CONFIGS)
+    );
+    // Return a default config to prevent errors
+    return {
+      feature: 'premium',
+      reason: 'Unlock premium features',
+      features: [],
+    };
+  }
+  return config;
 }
 
 /**
@@ -35,6 +50,8 @@ export function setUpgradeModalState(
   type: UpgradeModalType,
   setState: (feature: string, reason: string, features: PremiumFeature[]) => void
 ): void {
+  console.log('setUpgradeModalState called with type:', type);
   const config = getUpgradeModalConfig(type);
+  console.log('Retrieved config:', config);
   setState(config.feature, config.reason, config.features);
 }

--- a/src/popup/components/SettingsTabContent.svelte
+++ b/src/popup/components/SettingsTabContent.svelte
@@ -35,9 +35,11 @@
   }
 
   function handleConfigurePushReminder() {
+    console.log('handleConfigurePushReminder called, isUserPremium:', isUserPremium);
     if (isUserPremium) {
       dispatch('configurePushReminder');
     } else {
+      console.log('User is not premium, calling handleUpgradeClick with pushReminders');
       handleUpgradeClick('pushReminders');
     }
   }

--- a/src/popup/components/TabsView.svelte
+++ b/src/popup/components/TabsView.svelte
@@ -39,8 +39,8 @@
     dispatch('feedback');
   }
 
-  function handleUpgradeClick(type: any) {
-    dispatch('upgradeClick', type);
+  function handleUpgradeClick(event: CustomEvent<any>) {
+    dispatch('upgradeClick', event.detail);
   }
 
   function handleNewsletter() {


### PR DESCRIPTION
### **User description**
## Summary
- Fixed TypeError when clicking the "Configure Push Reminders" button in settings
- Bump version to 1.3.3

## Details
The error occurred because of incorrect event handling in the component hierarchy. When the upgrade modal was triggered from the push reminder configuration, the event detail was not properly extracted, causing `undefined` to be passed to the upgrade modal configuration lookup.

### Changes Made:
1. **Fixed event handling in TabsView.svelte**: Updated `handleUpgradeClick` to properly extract the event detail from CustomEvent
2. **Added defensive coding in upgradeModal.ts**: Added error handling to prevent crashes when invalid upgrade modal types are passed
3. **Added debugging logs**: Added console logging to help track the upgrade modal flow for future debugging

## Test Plan
- [x] Build extension without errors
- [x] Click "Configure Push Reminders" button - no errors thrown
- [x] Upgrade modal displays correctly when clicking as non-premium user
- [x] Version bumped to 1.3.3 in package.json and manifest.json


___

### **PR Type**
Bug fix


___

### **Description**
• Fixed TypeError in Configure Push Reminders button
• Added error handling for invalid upgrade modal types
• Added debugging logs for upgrade modal flow
• Bumped version to 1.3.3


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upgradeModal.ts</strong><dd><code>Add error handling and logging to upgrade modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/utils/upgradeModal.ts

• Added null check and error handling for invalid upgrade modal types<br> <br>• Added default fallback config to prevent crashes<br> • Added console <br>logging for debugging upgrade modal flow


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/97/files#diff-f68959d30efe12cb657ceaaccd8ce3ff37390f524cf3e4a35dac90a32d371e03">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update version in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

• Updated current version from v1.3.2 to v1.3.3


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/97/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump extension version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifest.json

• Bumped version from "1.3.2" to "1.3.3"


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/97/files#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

• Updated version from "1.3.2" to "1.3.3"


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/97/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SettingsTabContent.svelte</strong><dd><code>Add debugging logs to settings component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/popup/components/SettingsTabContent.svelte

• Added console logging in <code>handleConfigurePushReminder</code> function<br> • <br>Added debug logs for premium user status and upgrade flow


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/97/files#diff-72de44773913ebd2afc7bc7537942326d8b07bfc01d9da9540dfaa9989ebd110">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TabsView.svelte</strong><dd><code>Fix event handling in upgrade click</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/popup/components/TabsView.svelte

• Fixed <code>handleUpgradeClick</code> to properly extract event detail from <br>CustomEvent<br> • Changed parameter type from <code>any</code> to <code>CustomEvent<any></code>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/97/files#diff-dc308baf1f8f4e3e6bb0fcc6ba0f4d0e031fdb3eaca16ace720fcd80c61697c4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>