### PR TITLE
fix: exclude test-fixtures from test coverage reports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,12 @@ export default {
   collectCoverage: true,
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/src/background/test-fixtures/',
+    '<rootDir>/src/content/test-fixtures/',
+    '<rootDir>/src/services/__tests__/test-fixtures/',
+  ],
   globals: {
     'ts-jest': {
       useESM: true,


### PR DESCRIPTION
### **User description**
## Summary
- Added `coveragePathIgnorePatterns` to jest.config.js
- Excluded all test-fixtures directories from coverage calculations
- Coverage reports now focus only on production code

## Problem
Test fixture files (mock implementations, test helpers, and test data) were being included in coverage reports, artificially lowering coverage metrics. These files are not production code and should be excluded from coverage calculations.

## Solution
Updated jest.config.js to exclude the following directories from coverage:
- `src/background/test-fixtures/`
- `src/content/test-fixtures/`  
- `src/services/__tests__/test-fixtures/`

## Test Plan
- [x] Verified test-fixtures files no longer appear in coverage reports
- [x] All tests pass with `pnpm test:ci`
- [x] Build succeeds with `pnpm build`
- [x] No linting issues with `pnpm lint`
- [x] Coverage percentages now reflect only production code

Fixes #116


___

### **PR Type**
Bug fix


___

### **Description**
• Added `coveragePathIgnorePatterns` to Jest configuration
• Excluded test-fixtures directories from coverage calculations
• Improved accuracy of test coverage metrics


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.config.js</strong><dd><code>Configure Jest to ignore test fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jest.config.js

• Added <code>coveragePathIgnorePatterns</code> configuration array<br> • Excluded <br>three test-fixtures directories from coverage<br> • Includes node_modules <br>and specific test fixture paths


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/118/files#diff-1e058ca1442e46581b13571fb8d261f9e1f5657e26c96634d4c1072f0f0347f1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>