### PR TITLE
feat: implement extension uninstall feedback integration (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🎉 New Features
 
 - **Post-installation welcome flow** - Added welcome page with onboarding for new users installing the extension
+- **Uninstall feedback integration** - Track anonymous usage statistics and redirect to feedback page on uninstall
 
 ### 🧪 Testing & Quality Improvements
 

--- a/src/background/BackgroundService.ts
+++ b/src/background/BackgroundService.ts
@@ -223,19 +223,14 @@ export class BackgroundService {
       const authMethod = localSettings.authenticationMethod || 'pat';
 
       // Track authentication method
-      try {
-        await this.usageTracker.updateUsageStats('auth_method_changed', {
-          authMethod:
-            authMethod === 'github_app'
-              ? 'github-app'
-              : settings?.gitHubSettings?.githubToken
-                ? 'pat'
-                : 'none',
-        });
-      } catch (error) {
-        logger.warn('Failed to track auth method change:', error);
-        // Continue without tracking - don't break the main flow
-      }
+      await this.usageTracker.updateUsageStats('auth_method_changed', {
+        authMethod:
+          authMethod === 'github_app'
+            ? 'github-app'
+            : settings?.gitHubSettings?.githubToken
+              ? 'pat'
+              : 'none',
+      });
 
       if (authMethod === 'github_app') {
         // Initialize with GitHub App authentication
@@ -259,15 +254,10 @@ export class BackgroundService {
       logger.error('Failed to initialize GitHub service:', error);
 
       // Track initialization error
-      try {
-        await this.usageTracker.trackError(
-          error instanceof Error ? error : new Error('Failed to initialize GitHub service'),
-          'github_service_init'
-        );
-      } catch (trackingError) {
-        logger.warn('Failed to track GitHub service init error:', trackingError);
-        // Continue without tracking - don't break the main flow
-      }
+      await this.usageTracker.trackError(
+        error instanceof Error ? error : new Error('Failed to initialize GitHub service'),
+        'github_service_init'
+      );
 
       this.githubService = null;
     }
@@ -426,12 +416,7 @@ export class BackgroundService {
         // Check for analytics preference changes
         if ('analyticsEnabled' in changes) {
           logger.info('📊 Analytics preference changed, updating uninstall URL...');
-          try {
-            await this.usageTracker.setUninstallURL();
-          } catch (error) {
-            logger.warn('Failed to update uninstall URL:', error);
-            // Continue without tracking - don't break the main flow
-          }
+          await this.usageTracker.setUninstallURL();
         }
 
         const settingsChanged = ['githubToken', 'repoOwner', 'repoName', 'branch'].some(
@@ -758,12 +743,7 @@ export class BackgroundService {
         await this.operationStateManager.completeOperation(operationId);
 
         // Track successful push
-        try {
-          await this.usageTracker.updateUsageStats('push_completed');
-        } catch (error) {
-          logger.warn('Failed to track push completion:', error);
-          // Continue without tracking - don't break the main flow
-        }
+        await this.usageTracker.updateUsageStats('push_completed');
 
         this.sendResponse(port, {
           type: 'UPLOAD_STATUS',
@@ -796,15 +776,10 @@ export class BackgroundService {
         );
 
         // Track error
-        try {
-          await this.usageTracker.trackError(
-            decodeError instanceof Error ? decodeError : new Error(errorMessage),
-            'push_failed'
-          );
-        } catch (trackingError) {
-          logger.warn('Failed to track push error:', trackingError);
-          // Continue without tracking - don't break the main flow
-        }
+        await this.usageTracker.trackError(
+          decodeError instanceof Error ? decodeError : new Error(errorMessage),
+          'push_failed'
+        );
 
         if (isGitHubError) {
           // Extract the original GitHub error message if available
@@ -844,15 +819,10 @@ export class BackgroundService {
         );
 
         // Track error
-        try {
-          await this.usageTracker.trackError(
-            error instanceof Error ? error : new Error('Unknown error occurred'),
-            'push_failed_outer'
-          );
-        } catch (trackingError) {
-          logger.warn('Failed to track outer push error:', trackingError);
-          // Continue without tracking - don't break the main flow
-        }
+        await this.usageTracker.trackError(
+          error instanceof Error ? error : new Error('Unknown error occurred'),
+          'push_failed_outer'
+        );
       }
 
       this.sendResponse(port, {

--- a/src/background/BackgroundService.ts
+++ b/src/background/BackgroundService.ts
@@ -190,7 +190,12 @@ export class BackgroundService {
 
   private async initialize(): Promise<void> {
     // Initialize usage tracking
-    await this.usageTracker.initializeUsageData();
+    // We continue even if usage tracking fails to ensure the extension remains functional
+    try {
+      await this.usageTracker.initializeUsageData();
+    } catch (error) {
+      logger.error('Failed to initialize usage tracking, continuing without it:', error);
+    }
 
     const githubService = await this.initializeGitHubService();
     this.setupZipHandler(githubService!);

--- a/src/background/UsageTracker.ts
+++ b/src/background/UsageTracker.ts
@@ -17,13 +17,8 @@ export class UsageTracker {
    * Initialize usage data on extension install or update
    */
   async initializeUsageData(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       chrome.storage.local.get(['usageData'], (result) => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(`Failed to get usage data: ${chrome.runtime.lastError.message}`));
-          return;
-        }
-
         const now = new Date().toISOString();
         const manifest = chrome.runtime.getManifest();
 
@@ -39,17 +34,9 @@ export class UsageTracker {
         // Update version if it changed
         usageData.extensionVersion = manifest.version;
 
-        chrome.storage.local.set({ usageData }, async () => {
-          if (chrome.runtime.lastError) {
-            reject(new Error(`Failed to set usage data: ${chrome.runtime.lastError.message}`));
-            return;
-          }
-          try {
-            await this.setUninstallURL();
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
+        chrome.storage.local.set({ usageData }, () => {
+          this.setUninstallURL();
+          resolve();
         });
       });
     });
@@ -62,13 +49,8 @@ export class UsageTracker {
     eventType: string,
     data?: { authMethod?: UsageData['authMethod'] }
   ): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       chrome.storage.local.get(['usageData'], (result) => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(`Failed to get usage data: ${chrome.runtime.lastError.message}`));
-          return;
-        }
-
         const usageData: UsageData = result.usageData || this.getDefaultUsageData();
 
         usageData.lastActiveDate = new Date().toISOString();
@@ -84,17 +66,9 @@ export class UsageTracker {
             break;
         }
 
-        chrome.storage.local.set({ usageData }, async () => {
-          if (chrome.runtime.lastError) {
-            reject(new Error(`Failed to set usage data: ${chrome.runtime.lastError.message}`));
-            return;
-          }
-          try {
-            await this.setUninstallURL();
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
+        chrome.storage.local.set({ usageData }, () => {
+          this.setUninstallURL();
+          resolve();
         });
       });
     });
@@ -104,13 +78,8 @@ export class UsageTracker {
    * Track errors for uninstall feedback
    */
   async trackError(error: Error, context: string): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       chrome.storage.local.get(['errorLog', 'usageData'], (result) => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(`Failed to get error data: ${chrome.runtime.lastError.message}`));
-          return;
-        }
-
         const errorLog: ErrorLogEntry[] = result.errorLog || [];
         const usageData: UsageData = result.usageData || this.getDefaultUsageData();
 
@@ -135,17 +104,9 @@ export class UsageTracker {
             errorLog: recentErrors,
             usageData,
           },
-          async () => {
-            if (chrome.runtime.lastError) {
-              reject(new Error(`Failed to set error data: ${chrome.runtime.lastError.message}`));
-              return;
-            }
-            try {
-              await this.setUninstallURL();
-              resolve();
-            } catch (error) {
-              reject(error);
-            }
+          () => {
+            this.setUninstallURL();
+            resolve();
           }
         );
       });
@@ -156,39 +117,20 @@ export class UsageTracker {
    * Set the uninstall URL with anonymous usage parameters
    */
   async setUninstallURL(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       // Get analytics preference from sync storage (same as AnalyticsToggle component)
       chrome.storage.sync.get(['analyticsEnabled'], (syncResult) => {
-        if (chrome.runtime.lastError) {
-          reject(
-            new Error(`Failed to get analytics preference: ${chrome.runtime.lastError.message}`)
-          );
-          return;
-        }
-
         const analyticsEnabled = syncResult.analyticsEnabled ?? true; // Default to true if not set
 
         // If analytics is disabled, clear the uninstall URL
         if (!analyticsEnabled) {
-          chrome.runtime.setUninstallURL('', () => {
-            if (chrome.runtime.lastError) {
-              reject(
-                new Error(`Failed to clear uninstall URL: ${chrome.runtime.lastError.message}`)
-              );
-              return;
-            }
-            resolve();
-          });
+          chrome.runtime.setUninstallURL('');
+          resolve();
           return;
         }
 
         // Get usage data from local storage
         chrome.storage.local.get(['usageData'], (localResult) => {
-          if (chrome.runtime.lastError) {
-            reject(new Error(`Failed to get usage data: ${chrome.runtime.lastError.message}`));
-            return;
-          }
-
           const usageData: UsageData = localResult.usageData || this.getDefaultUsageData();
           const manifest = chrome.runtime.getManifest();
 
@@ -201,13 +143,8 @@ export class UsageTracker {
           });
 
           const uninstallUrl = `${this.UNINSTALL_FEEDBACK_BASE_URL}?${params.toString()}`;
-          chrome.runtime.setUninstallURL(uninstallUrl, () => {
-            if (chrome.runtime.lastError) {
-              reject(new Error(`Failed to set uninstall URL: ${chrome.runtime.lastError.message}`));
-              return;
-            }
-            resolve();
-          });
+          chrome.runtime.setUninstallURL(uninstallUrl);
+          resolve();
         });
       });
     });

--- a/src/background/UsageTracker.ts
+++ b/src/background/UsageTracker.ts
@@ -1,0 +1,195 @@
+/**
+ * UsageTracker - Tracks extension usage statistics and manages uninstall feedback URL
+ *
+ * This module is responsible for:
+ * - Tracking usage statistics (installs, pushes, errors)
+ * - Managing error logging
+ * - Setting up uninstall feedback URL with anonymous usage data
+ * - Respecting user privacy and telemetry preferences
+ */
+
+import type { UsageData, ErrorLogEntry } from '../lib/types';
+
+export class UsageTracker {
+  private readonly UNINSTALL_FEEDBACK_BASE_URL = 'https://bolt2github.com/uninstall-feedback';
+
+  /**
+   * Initialize usage data on extension install or update
+   */
+  async initializeUsageData(): Promise<void> {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(['usageData'], (result) => {
+        const now = new Date().toISOString();
+        const manifest = chrome.runtime.getManifest();
+
+        const usageData: UsageData = result.usageData || {
+          installDate: now,
+          lastActiveDate: now,
+          totalPushes: 0,
+          authMethod: 'none',
+          extensionVersion: manifest.version,
+          errorCount: 0,
+        };
+
+        // Update version if it changed
+        usageData.extensionVersion = manifest.version;
+
+        chrome.storage.local.set({ usageData }, () => {
+          this.setUninstallURL();
+          resolve();
+        });
+      });
+    });
+  }
+
+  /**
+   * Update usage statistics based on events
+   */
+  async updateUsageStats(
+    eventType: string,
+    data?: { authMethod?: UsageData['authMethod'] }
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(['usageData'], (result) => {
+        const usageData: UsageData = result.usageData || this.getDefaultUsageData();
+
+        usageData.lastActiveDate = new Date().toISOString();
+
+        switch (eventType) {
+          case 'push_completed':
+            usageData.totalPushes++;
+            break;
+          case 'auth_method_changed':
+            if (data?.authMethod) {
+              usageData.authMethod = data.authMethod;
+            }
+            break;
+        }
+
+        chrome.storage.local.set({ usageData }, () => {
+          this.setUninstallURL();
+          resolve();
+        });
+      });
+    });
+  }
+
+  /**
+   * Track errors for uninstall feedback
+   */
+  async trackError(error: Error, context: string): Promise<void> {
+    return new Promise((resolve) => {
+      chrome.storage.local.get(['errorLog', 'usageData'], (result) => {
+        const errorLog: ErrorLogEntry[] = result.errorLog || [];
+        const usageData: UsageData = result.usageData || this.getDefaultUsageData();
+
+        const errorEntry: ErrorLogEntry = {
+          timestamp: new Date().toISOString(),
+          message: error.message,
+          context: context,
+          stack: error.stack,
+        };
+
+        errorLog.push(errorEntry);
+
+        // Keep only last 10 errors
+        const recentErrors = errorLog.slice(-10);
+
+        // Update usage data error count
+        usageData.errorCount++;
+        usageData.lastError = error.message;
+
+        chrome.storage.local.set(
+          {
+            errorLog: recentErrors,
+            usageData,
+          },
+          () => {
+            this.setUninstallURL();
+            resolve();
+          }
+        );
+      });
+    });
+  }
+
+  /**
+   * Set the uninstall URL with anonymous usage parameters
+   */
+  async setUninstallURL(): Promise<void> {
+    return new Promise((resolve) => {
+      // Get analytics preference from sync storage (same as AnalyticsToggle component)
+      chrome.storage.sync.get(['analyticsEnabled'], (syncResult) => {
+        const analyticsEnabled = syncResult.analyticsEnabled ?? true; // Default to true if not set
+
+        // If analytics is disabled, clear the uninstall URL
+        if (!analyticsEnabled) {
+          chrome.runtime.setUninstallURL('');
+          resolve();
+          return;
+        }
+
+        // Get usage data from local storage
+        chrome.storage.local.get(['usageData'], (localResult) => {
+          const usageData: UsageData = localResult.usageData || this.getDefaultUsageData();
+          const manifest = chrome.runtime.getManifest();
+
+          const params = new URLSearchParams({
+            v: manifest.version,
+            d: this.calculateDaysSinceInstall(usageData.installDate).toString(),
+            p: usageData.totalPushes.toString(),
+            a: usageData.authMethod,
+            e: (usageData.errorCount > 0).toString(),
+          });
+
+          const uninstallUrl = `${this.UNINSTALL_FEEDBACK_BASE_URL}?${params.toString()}`;
+          chrome.runtime.setUninstallURL(uninstallUrl);
+          resolve();
+        });
+      });
+    });
+  }
+
+  /**
+   * Calculate days since installation
+   */
+  private calculateDaysSinceInstall(installDate: string): number {
+    try {
+      const install = new Date(installDate);
+      const now = new Date();
+
+      // Check for invalid date
+      if (isNaN(install.getTime())) {
+        return 0;
+      }
+
+      // Calculate difference (negative if install date is in future)
+      const diffTime = now.getTime() - install.getTime();
+
+      // Return 0 for future dates
+      if (diffTime < 0) {
+        return 0;
+      }
+
+      const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+      return diffDays;
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * Get default usage data structure
+   */
+  private getDefaultUsageData(): UsageData {
+    const manifest = chrome.runtime.getManifest();
+    return {
+      installDate: new Date().toISOString(),
+      lastActiveDate: new Date().toISOString(),
+      totalPushes: 0,
+      authMethod: 'none',
+      extensionVersion: manifest.version,
+      errorCount: 0,
+    };
+  }
+}

--- a/src/background/__tests__/UsageTracker.test.ts
+++ b/src/background/__tests__/UsageTracker.test.ts
@@ -1,0 +1,342 @@
+/**
+ * UsageTracker Tests
+ *
+ * Tests for tracking extension usage statistics, error logging, and uninstall URL generation
+ * for the uninstall feedback feature.
+ */
+
+import type { UsageData, ErrorLogEntry } from '../../lib/types';
+import { UsageTracker } from '../UsageTracker';
+
+// Mock chrome APIs
+const mockChromeStorage = {
+  local: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+  sync: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+};
+
+const mockChromeRuntime = {
+  getManifest: jest.fn(() => ({ version: '1.3.5' })),
+  setUninstallURL: jest.fn(),
+};
+
+// Replace global chrome object
+global.chrome = {
+  storage: mockChromeStorage,
+  runtime: mockChromeRuntime,
+} as typeof chrome;
+
+describe('UsageTracker', () => {
+  let usageTracker: UsageTracker;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    usageTracker = new UsageTracker();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('initializeUsageData', () => {
+    it('should create initial usage data on first install', async () => {
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({});
+      });
+
+      mockChromeStorage.sync.get.mockImplementation((keys, callback) => {
+        callback({ analyticsEnabled: true });
+      });
+
+      let savedData: Record<string, unknown>;
+      mockChromeStorage.local.set.mockImplementation((data, callback) => {
+        savedData = data;
+        if (callback) callback();
+      });
+
+      await usageTracker.initializeUsageData();
+
+      expect(mockChromeStorage.local.get).toHaveBeenCalledWith(['usageData'], expect.any(Function));
+
+      expect(savedData.usageData).toMatchObject({
+        installDate: expect.any(String),
+        lastActiveDate: expect.any(String),
+        totalPushes: 0,
+        authMethod: 'none',
+        extensionVersion: '1.3.5',
+        errorCount: 0,
+      });
+    });
+
+    it('should preserve existing usage data', async () => {
+      const existingData: UsageData = {
+        installDate: '2024-01-01T00:00:00.000Z',
+        lastActiveDate: '2024-01-15T00:00:00.000Z',
+        totalPushes: 10,
+        authMethod: 'github-app',
+        extensionVersion: '1.3.4',
+        errorCount: 2,
+        lastError: 'Test error',
+      };
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({ usageData: existingData });
+      });
+
+      let savedData: Record<string, unknown>;
+      mockChromeStorage.local.set.mockImplementation((data, callback) => {
+        savedData = data;
+        if (callback) callback();
+      });
+
+      await usageTracker.initializeUsageData();
+
+      expect(savedData.usageData).toMatchObject({
+        ...existingData,
+        extensionVersion: '1.3.5', // Should update version
+      });
+    });
+  });
+
+  describe('updateUsageStats', () => {
+    it('should increment push count and update last active date', async () => {
+      const existingData: UsageData = {
+        installDate: '2024-01-01T00:00:00.000Z',
+        lastActiveDate: '2024-01-15T00:00:00.000Z',
+        totalPushes: 5,
+        authMethod: 'pat',
+        extensionVersion: '1.3.5',
+        errorCount: 0,
+      };
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({ usageData: existingData });
+      });
+
+      let savedData: Record<string, unknown>;
+      mockChromeStorage.local.set.mockImplementation((data, callback) => {
+        savedData = data;
+        if (callback) callback();
+      });
+
+      await usageTracker.updateUsageStats('push_completed');
+
+      expect(savedData.usageData).toMatchObject({
+        ...existingData,
+        totalPushes: 6,
+        lastActiveDate: expect.any(String),
+      });
+    });
+
+    it('should update authentication method when changed', async () => {
+      const existingData: UsageData = {
+        installDate: '2024-01-01T00:00:00.000Z',
+        lastActiveDate: '2024-01-15T00:00:00.000Z',
+        totalPushes: 5,
+        authMethod: 'none',
+        extensionVersion: '1.3.5',
+        errorCount: 0,
+      };
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({ usageData: existingData });
+      });
+
+      let savedData: Record<string, unknown>;
+      mockChromeStorage.local.set.mockImplementation((data, callback) => {
+        savedData = data;
+        if (callback) callback();
+      });
+
+      await usageTracker.updateUsageStats('auth_method_changed', { authMethod: 'github-app' });
+
+      expect(savedData.usageData.authMethod).toBe('github-app');
+    });
+  });
+
+  describe('trackError', () => {
+    it('should add error to error log and increment error count', async () => {
+      const existingData: UsageData = {
+        installDate: '2024-01-01T00:00:00.000Z',
+        lastActiveDate: '2024-01-15T00:00:00.000Z',
+        totalPushes: 5,
+        authMethod: 'pat',
+        extensionVersion: '1.3.5',
+        errorCount: 1,
+      };
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        if (keys.includes('usageData')) {
+          callback({ usageData: existingData, errorLog: [] });
+        } else {
+          callback({ errorLog: [] });
+        }
+      });
+
+      let savedData: Record<string, unknown>;
+      mockChromeStorage.local.set.mockImplementation((data, callback) => {
+        savedData = data;
+        if (callback) callback();
+      });
+
+      const error = new Error('Test error message');
+      await usageTracker.trackError(error, 'test_context');
+
+      expect(savedData.errorLog).toHaveLength(1);
+      expect(savedData.errorLog[0]).toMatchObject({
+        timestamp: expect.any(String),
+        message: 'Test error message',
+        context: 'test_context',
+        stack: expect.any(String),
+      });
+
+      expect(savedData.usageData.errorCount).toBe(2);
+      expect(savedData.usageData.lastError).toBe('Test error message');
+    });
+
+    it('should keep only last 10 errors', async () => {
+      const existingErrors: ErrorLogEntry[] = Array.from({ length: 10 }, (_, i) => ({
+        timestamp: new Date(2024, 0, i + 1).toISOString(),
+        message: `Error ${i}`,
+        context: 'test',
+      }));
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({
+          errorLog: existingErrors,
+          usageData: {
+            installDate: '2024-01-01T00:00:00.000Z',
+            lastActiveDate: '2024-01-15T00:00:00.000Z',
+            totalPushes: 5,
+            authMethod: 'pat',
+            extensionVersion: '1.3.5',
+            errorCount: 10,
+          },
+        });
+      });
+
+      let savedData: Record<string, unknown>;
+      mockChromeStorage.local.set.mockImplementation((data, callback) => {
+        savedData = data;
+        if (callback) callback();
+      });
+
+      const newError = new Error('New error');
+      await usageTracker.trackError(newError, 'new_context');
+
+      expect(savedData.errorLog).toHaveLength(10);
+      expect(savedData.errorLog[9].message).toBe('New error');
+      expect(savedData.errorLog[0].message).toBe('Error 1'); // First error should be removed
+    });
+  });
+
+  describe('setUninstallURL', () => {
+    it('should generate correct uninstall URL with usage parameters', async () => {
+      const usageData: UsageData = {
+        installDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days ago
+        lastActiveDate: new Date().toISOString(),
+        totalPushes: 15,
+        authMethod: 'github-app',
+        extensionVersion: '1.3.5',
+        errorCount: 2,
+      };
+
+      mockChromeStorage.sync.get.mockImplementation((keys, callback) => {
+        callback({ analyticsEnabled: true });
+      });
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({ usageData });
+      });
+
+      await usageTracker.setUninstallURL();
+
+      expect(mockChromeRuntime.setUninstallURL).toHaveBeenCalledWith(
+        expect.stringContaining('https://bolt2github.com/uninstall-feedback?')
+      );
+
+      const urlCall = mockChromeRuntime.setUninstallURL.mock.calls[0][0];
+      const url = new URL(urlCall);
+      const params = url.searchParams;
+
+      expect(params.get('v')).toBe('1.3.5');
+      expect(params.get('d')).toBe('30');
+      expect(params.get('p')).toBe('15');
+      expect(params.get('a')).toBe('github-app');
+      expect(params.get('e')).toBe('true');
+    });
+
+    it('should not set uninstall URL if analytics is disabled', async () => {
+      mockChromeStorage.sync.get.mockImplementation((keys, callback) => {
+        callback({ analyticsEnabled: false });
+      });
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({
+          usageData: {
+            installDate: new Date().toISOString(),
+            lastActiveDate: new Date().toISOString(),
+            totalPushes: 0,
+            authMethod: 'none',
+            extensionVersion: '1.3.5',
+            errorCount: 0,
+          },
+        });
+      });
+
+      await usageTracker.setUninstallURL();
+
+      expect(mockChromeRuntime.setUninstallURL).toHaveBeenCalledWith('');
+    });
+
+    it('should handle missing usage data gracefully', async () => {
+      mockChromeStorage.sync.get.mockImplementation((keys, callback) => {
+        callback({ analyticsEnabled: true });
+      });
+
+      mockChromeStorage.local.get.mockImplementation((keys, callback) => {
+        callback({});
+      });
+
+      await usageTracker.setUninstallURL();
+
+      expect(mockChromeRuntime.setUninstallURL).toHaveBeenCalledWith(
+        expect.stringContaining('https://bolt2github.com/uninstall-feedback?')
+      );
+
+      const urlCall = mockChromeRuntime.setUninstallURL.mock.calls[0][0];
+      const url = new URL(urlCall);
+      const params = url.searchParams;
+
+      expect(params.get('v')).toBe('1.3.5');
+      expect(params.get('d')).toBe('0');
+      expect(params.get('p')).toBe('0');
+      expect(params.get('a')).toBe('none');
+      expect(params.get('e')).toBe('false');
+    });
+  });
+
+  describe('calculateDaysSinceInstall', () => {
+    it('should calculate correct days since install', () => {
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+      const days = usageTracker['calculateDaysSinceInstall'](thirtyDaysAgo);
+      expect(days).toBe(30);
+    });
+
+    it('should return 0 for future dates', () => {
+      const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      const days = usageTracker['calculateDaysSinceInstall'](tomorrow);
+      expect(days).toBe(0);
+    });
+
+    it('should return 0 for invalid dates', () => {
+      const days = usageTracker['calculateDaysSinceInstall']('invalid-date');
+      expect(days).toBe(0);
+    });
+  });
+});

--- a/src/background/test-fixtures/BackgroundServiceMocks.ts
+++ b/src/background/test-fixtures/BackgroundServiceMocks.ts
@@ -389,6 +389,32 @@ export class MockOperationStateManager {
 }
 
 // =============================================================================
+// USAGE TRACKER MOCK
+// =============================================================================
+
+export class MockUsageTracker {
+  initializeUsageData = jest.fn(async (): Promise<void> => {
+    // Mock implementation - does nothing
+  });
+
+  updateUsageStats = jest.fn(async (eventType: string, data?: any): Promise<void> => {
+    // Mock implementation - does nothing
+  });
+
+  trackError = jest.fn(async (error: Error, context: string): Promise<void> => {
+    // Mock implementation - does nothing
+  });
+
+  setUninstallURL = jest.fn(async (): Promise<void> => {
+    // Mock implementation - does nothing
+  });
+
+  reset(): void {
+    jest.clearAllMocks();
+  }
+}
+
+// =============================================================================
 // MOCK FACTORY
 // =============================================================================
 
@@ -399,6 +425,7 @@ export class MockServiceFactory {
   public tempRepoManager: MockBackgroundTempRepoManager;
   public supabaseAuthService: MockSupabaseAuthService;
   public operationStateManager: MockOperationStateManager;
+  public usageTracker: MockUsageTracker;
 
   constructor() {
     this.stateManager = new MockStateManager();
@@ -411,6 +438,7 @@ export class MockServiceFactory {
     );
     this.supabaseAuthService = new MockSupabaseAuthService();
     this.operationStateManager = new MockOperationStateManager();
+    this.usageTracker = new MockUsageTracker();
   }
 
   setupMocks(): void {
@@ -444,6 +472,10 @@ export class MockServiceFactory {
         getInstance: () => this.operationStateManager,
       },
     }));
+
+    jest.doMock('../UsageTracker', () => ({
+      UsageTracker: jest.fn(() => this.usageTracker),
+    }));
   }
 
   resetAllMocks(): void {
@@ -453,6 +485,7 @@ export class MockServiceFactory {
     this.tempRepoManager.reset();
     this.supabaseAuthService.reset();
     this.operationStateManager.reset();
+    this.usageTracker.reset();
   }
 
   // Scenario setup methods
@@ -503,5 +536,6 @@ export const ServiceMocks = {
   MockBackgroundTempRepoManager,
   MockSupabaseAuthService,
   MockOperationStateManager,
+  MockUsageTracker,
   MockServiceFactory,
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -122,3 +122,34 @@ export interface OnboardingData {
   installedVersion: string;
   welcomePageViewed: boolean;
 }
+
+/**
+ * Interface for usage data tracking
+ */
+export interface UsageData {
+  installDate: string;
+  lastActiveDate: string;
+  totalPushes: number;
+  authMethod: 'github-app' | 'pat' | 'none';
+  extensionVersion: string;
+  errorCount: number;
+  lastError?: string;
+}
+
+/**
+ * Interface for error log entry
+ */
+export interface ErrorLogEntry {
+  timestamp: string;
+  message: string;
+  context: string;
+  stack?: string;
+}
+
+/**
+ * Interface for telemetry settings
+ */
+export interface TelemetrySettings {
+  enabled: boolean;
+  anonymousId?: string;
+}


### PR DESCRIPTION
### **User description**
## Summary

This PR implements the extension-side functionality for uninstall feedback as described in issue #110. When users uninstall the extension, they will be redirected to a feedback page with anonymous usage statistics to help understand why users uninstall and improve the extension.

## Changes Made

### 1. **UsageTracker Implementation** (`src/background/UsageTracker.ts`)
- Tracks anonymous usage statistics (install date, push count, auth method, errors)
- Generates dynamic uninstall URL with privacy-compliant parameters
- Respects user analytics opt-out preferences
- Maintains error log with 10-error limit

### 2. **BackgroundService Integration**
- Initializes usage tracking on extension startup
- Tracks successful push completions
- Logs errors with context for debugging
- Monitors authentication method changes
- Updates uninstall URL when analytics preferences change

### 3. **Privacy-First Approach**
- No PII (Personally Identifiable Information) collected
- Uses existing analytics toggle in settings
- Clears uninstall URL when analytics disabled
- Only collects: version, days installed, push count, auth method, error flag

### 4. **Comprehensive Test Coverage**
- 12 tests covering all functionality
- Tests for edge cases (future dates, invalid data)
- Verifies analytics opt-out compliance
- Ensures proper callback handling

## Test Results

✅ All tests passing (12/12)
✅ Build successful with no TypeScript errors
✅ Lint issues fixed

## Related Issues

- Implements: #110
- Web App Issue: https://github.com/aidrivencoder/bolt2github/issues/36
- Backend Implementation: aidrivencoder/bolt2github#38

## Testing Instructions

1. Install the extension
2. Perform some pushes to track usage
3. Toggle analytics on/off in settings
4. Check chrome://extensions → Extension details → Remove extension
5. Verify redirect to feedback page with correct parameters

## URL Parameters

When uninstalling, users are redirected to:
```
https://bolt2github.com/uninstall-feedback?v=1.3.5&d=30&p=15&a=github-app&e=true
```

- `v` - Extension version
- `d` - Days since installation
- `p` - Total pushes count
- `a` - Authentication method (github-app/pat/none)
- `e` - Error encountered (true/false)


___

### **PR Type**
Enhancement


___

### **Description**
• Add UsageTracker class for anonymous usage statistics
• Track push completions, errors, and authentication methods
• Generate dynamic uninstall URL with privacy-compliant parameters
• Integrate with existing analytics preferences and comprehensive test coverage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BackgroundService.ts</strong><dd><code>Integrate usage tracking into background service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/background/BackgroundService.ts

• Import and initialize UsageTracker instance<br> • Track authentication <br>method changes during GitHub service initialization<br> • Log errors with <br>context for debugging purposes<br> • Track successful push completions and <br>failed operations<br> • Monitor analytics preference changes to update <br>uninstall URL


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/121/files#diff-c6c6a7488dbcc7a9ee2285757501a92a23ab27e8694ff5b0378d5dfb3fafa98f">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UsageTracker.ts</strong><dd><code>Add usage tracking and uninstall feedback functionality</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/background/UsageTracker.ts

• Create new class to track anonymous usage statistics<br> • Implement <br>error logging with 10-error limit<br> • Generate dynamic uninstall URL <br>with privacy-compliant parameters<br> • Respect user analytics opt-out <br>preferences<br> • Calculate days since installation for feedback data


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/121/files#diff-4581f88660f83a37be2fa314f9ce0ea64159eb2c0276df67c7e7d66ba625df31">+195/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add type definitions for usage tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/types.ts

• Add UsageData interface for tracking extension usage<br> • Add <br>ErrorLogEntry interface for error logging<br> • Add TelemetrySettings <br>interface for analytics preferences


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/121/files#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UsageTracker.test.ts</strong><dd><code>Add comprehensive test coverage for UsageTracker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/background/__tests__/UsageTracker.test.ts

• Add comprehensive test suite with 12 test cases<br> • Test usage data <br>initialization and statistics updates<br> • Verify error tracking and <br>logging functionality<br> • Test uninstall URL generation with various <br>scenarios<br> • Ensure privacy compliance and analytics opt-out handling


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/121/files#diff-c0c2bdee9218cbe897fcc564a3c3c17144a69b28ea321d9430a2725ede45f27f">+342/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>