### PR TITLE
fix(issue-125): implement 12-hour log retention with comprehensive Chrome alarms API testing

### DIFF
--- a/src/background/BackgroundService.ts
+++ b/src/background/BackgroundService.ts
@@ -203,15 +203,10 @@ export class BackgroundService {
     const logStorage = getLogStorage();
     logStorage.rotateLogs();
 
-    // Set up rotation using JavaScript timer instead of chrome.alarms
-    // This avoids requiring new permissions
-    const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
-
-    // Use setInterval for periodic rotation
-    setInterval(() => {
-      logger.info('Running scheduled log rotation');
-      logStorage.rotateLogs();
-    }, SIX_HOURS_MS);
+    // Set up rotation using chrome.alarms for reliability
+    // Check every 3 hours for logs older than 12 hours (configured in LogStorageManager)
+    // This ensures logs are retained for a maximum of ~15 hours (12 + 3)
+    chrome.alarms.create('logRotation', { periodInMinutes: 180 }); // 3 hours = 180 minutes
 
     // Also check and rotate logs when the service worker wakes up
     // This handles cases where the interval might be cleared

--- a/src/background/BackgroundService.ts
+++ b/src/background/BackgroundService.ts
@@ -204,9 +204,8 @@ export class BackgroundService {
     logStorage.rotateLogs();
 
     // Set up rotation using chrome.alarms for reliability
-    // Check every 3 hours for activity-based log cleanup (configured in LogStorageManager)
-    // Retains 12 hours worth of actual logging activity, not just time-based cutoff
-    // This preserves debugging context during idle periods while preventing unbounded growth
+    // Check every 3 hours for time-based log cleanup (configured in LogStorageManager)
+    // Retains logs newer than 12 hours for debugging while preventing unbounded growth
     chrome.alarms.create('logRotation', { periodInMinutes: 180 }); // 3 hours = 180 minutes
 
     // Also check and rotate logs when the service worker wakes up

--- a/src/background/BackgroundService.ts
+++ b/src/background/BackgroundService.ts
@@ -204,9 +204,9 @@ export class BackgroundService {
     logStorage.rotateLogs();
 
     // Set up rotation using chrome.alarms for reliability
-    // Check every 3 hours for logs older than 12 hours (configured in LogStorageManager)
-    // Note: Logs may persist up to 15 hours total (12h retention + 3h check interval)
-    // This is an acceptable trade-off between cleanup precision and resource efficiency
+    // Check every 3 hours for activity-based log cleanup (configured in LogStorageManager)
+    // Retains 12 hours worth of actual logging activity, not just time-based cutoff
+    // This preserves debugging context during idle periods while preventing unbounded growth
     chrome.alarms.create('logRotation', { periodInMinutes: 180 }); // 3 hours = 180 minutes
 
     // Also check and rotate logs when the service worker wakes up

--- a/src/background/BackgroundService.ts
+++ b/src/background/BackgroundService.ts
@@ -205,7 +205,8 @@ export class BackgroundService {
 
     // Set up rotation using chrome.alarms for reliability
     // Check every 3 hours for logs older than 12 hours (configured in LogStorageManager)
-    // This ensures logs are retained for a maximum of ~15 hours (12 + 3)
+    // Note: Logs may persist up to 15 hours total (12h retention + 3h check interval)
+    // This is an acceptable trade-off between cleanup precision and resource efficiency
     chrome.alarms.create('logRotation', { periodInMinutes: 180 }); // 3 hours = 180 minutes
 
     // Also check and rotate logs when the service worker wakes up

--- a/src/background/__tests__/BackgroundService.alarms.test.ts
+++ b/src/background/__tests__/BackgroundService.alarms.test.ts
@@ -1,0 +1,352 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { BackgroundService } from '../BackgroundService';
+
+// Mock all dependencies
+jest.mock('../../services/UnifiedGitHubService');
+jest.mock('../../services/zipHandler');
+jest.mock('../StateManager', () => ({
+  StateManager: {
+    getInstance: jest.fn(() => ({
+      getGitHubSettings: jest.fn().mockResolvedValue({ gitHubSettings: {} }),
+    })),
+  },
+}));
+jest.mock('../TempRepoManager');
+jest.mock('../../content/services/SupabaseAuthService', () => ({
+  SupabaseAuthService: {
+    getInstance: jest.fn(() => ({
+      forceCheck: jest.fn(),
+      getAuthState: jest.fn().mockReturnValue({ isAuthenticated: true }),
+      addAuthStateListener: jest.fn(),
+      removeAuthStateListener: jest.fn(),
+    })),
+  },
+}));
+jest.mock('../../content/services/OperationStateManager', () => ({
+  OperationStateManager: {
+    getInstance: jest.fn(() => ({})),
+  },
+}));
+const mockLogStorage = {
+  getLogs: jest.fn().mockResolvedValue([]),
+  rotateLogs: jest.fn(),
+};
+
+jest.mock('../../lib/utils/logger', () => ({
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  })),
+  getLogStorage: jest.fn(() => mockLogStorage),
+}));
+jest.mock('../UsageTracker', () => ({
+  UsageTracker: jest.fn(() => ({
+    initializeUsageData: jest.fn().mockResolvedValue(undefined),
+    updateUsageStats: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+jest.mock('../../services/BoltProjectSyncService');
+
+// Mock chrome APIs with enhanced alarm functionality
+const mockAlarms = {
+  create: jest.fn(),
+  clear: jest.fn(),
+  clearAll: jest.fn(),
+  get: jest.fn(),
+  getAll: jest.fn(),
+  onAlarm: {
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  },
+};
+
+const mockStorage = {
+  local: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+  sync: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+  onChanged: {
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  },
+};
+
+const mockRuntime = {
+  onInstalled: {
+    addListener: jest.fn(),
+  },
+  onConnect: {
+    addListener: jest.fn(),
+  },
+  onMessage: {
+    addListener: jest.fn(),
+  },
+  onStartup: {
+    addListener: jest.fn(),
+  },
+  lastError: null,
+};
+
+const mockTabs = {
+  get: jest.fn(),
+  onUpdated: {
+    addListener: jest.fn(),
+  },
+  onRemoved: {
+    addListener: jest.fn(),
+  },
+  onActivated: {
+    addListener: jest.fn(),
+  },
+};
+
+global.chrome = {
+  alarms: mockAlarms,
+  storage: mockStorage,
+  runtime: mockRuntime,
+  tabs: mockTabs,
+} as any;
+
+describe('BackgroundService - Alarms Functionality', () => {
+  let service: BackgroundService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    // Setup mock returns
+    mockStorage.sync.get.mockResolvedValue({});
+    mockStorage.local.get.mockResolvedValue({});
+
+    service = new BackgroundService();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    service.destroy();
+  });
+
+  describe('Log Rotation Alarm', () => {
+    it('should create log rotation alarm on initialization', async () => {
+      await jest.runOnlyPendingTimersAsync();
+
+      expect(mockAlarms.create).toHaveBeenCalledWith('logRotation', { periodInMinutes: 180 });
+    });
+
+    it('should trigger log rotation on startup event', () => {
+      // Clear any previous calls
+      mockLogStorage.rotateLogs.mockClear();
+
+      // Get the startup listener
+      const startupListener = mockRuntime.onStartup.addListener.mock.calls[0][0];
+
+      // Trigger startup event
+      startupListener();
+
+      expect(mockLogStorage.rotateLogs).toHaveBeenCalled();
+    });
+
+    it('should trigger log rotation on installed event', async () => {
+      // Clear any previous calls
+      mockLogStorage.rotateLogs.mockClear();
+
+      // Get the installed listener
+      const installedListener = mockRuntime.onInstalled.addListener.mock.calls[0][0];
+
+      // Trigger installed event
+      await installedListener({ reason: 'install' });
+
+      expect(mockLogStorage.rotateLogs).toHaveBeenCalled();
+    });
+  });
+
+  describe('Keep-Alive Alarm', () => {
+    it('should create keep-alive alarm on initialization', async () => {
+      await jest.runOnlyPendingTimersAsync();
+
+      expect(mockAlarms.create).toHaveBeenCalledWith('keepAlive', { periodInMinutes: 1 });
+    });
+
+    it('should manage ports for active connections', () => {
+      // Verify ports Map exists
+      expect((service as any).ports).toBeInstanceOf(Map);
+
+      // Verify initial state
+      expect((service as any).ports.size).toBe(0);
+    });
+
+    it('should update activity timestamp on keep-alive alarm', () => {
+      const mockUpdateLastActivity = jest.spyOn(service as any, 'updateLastActivity');
+
+      // Get the alarm listener
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+
+      if (alarmListener) {
+        // Trigger keep-alive alarm
+        alarmListener({ name: 'keepAlive' });
+
+        expect(mockUpdateLastActivity).toHaveBeenCalled();
+        expect(mockStorage.local.set).toHaveBeenCalledWith({
+          lastKeepAlive: expect.any(Number),
+        });
+      }
+    });
+  });
+
+  describe('Sync Alarm', () => {
+    it('should create sync alarm on initialization', async () => {
+      await jest.runOnlyPendingTimersAsync();
+
+      expect(mockAlarms.create).toHaveBeenCalledWith('bolt-project-sync', { periodInMinutes: 5 });
+    });
+  });
+
+  describe('Alarm Event Handling', () => {
+    it('should register alarm event listener on initialization', async () => {
+      await jest.runOnlyPendingTimersAsync();
+
+      expect(mockAlarms.onAlarm.addListener).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should handle keep-alive alarm events', () => {
+      const mockUpdateLastActivity = jest.spyOn(service as any, 'updateLastActivity');
+
+      // Get the alarm listener
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+
+      if (alarmListener) {
+        // Trigger keep-alive alarm
+        alarmListener({ name: 'keepAlive' });
+
+        expect(mockUpdateLastActivity).toHaveBeenCalled();
+        expect(mockStorage.local.set).toHaveBeenCalledWith({
+          lastKeepAlive: expect.any(Number),
+        });
+      }
+    });
+
+    it('should handle log rotation alarm events', () => {
+      // Clear any previous calls
+      mockLogStorage.rotateLogs.mockClear();
+
+      // Get the alarm listener
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+
+      if (alarmListener) {
+        // Trigger log rotation alarm
+        alarmListener({ name: 'logRotation' });
+
+        expect(mockLogStorage.rotateLogs).toHaveBeenCalled();
+      }
+    });
+
+    it('should handle sync alarm events', () => {
+      const mockHandleSyncAlarm = jest
+        .spyOn(service as any, 'handleSyncAlarm')
+        .mockImplementation();
+
+      // Get the alarm listener
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+
+      if (alarmListener) {
+        // Trigger sync alarm
+        alarmListener({ name: 'bolt-project-sync' });
+
+        expect(mockHandleSyncAlarm).toHaveBeenCalled();
+      }
+    });
+
+    it('should ignore unknown alarm events', () => {
+      const mockUpdateLastActivity = jest.spyOn(service as any, 'updateLastActivity');
+      const mockHandleSyncAlarm = jest
+        .spyOn(service as any, 'handleSyncAlarm')
+        .mockImplementation();
+
+      // Clear any previous calls
+      mockLogStorage.rotateLogs.mockClear();
+
+      // Get the alarm listener
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+
+      if (alarmListener) {
+        // Trigger unknown alarm
+        alarmListener({ name: 'unknown-alarm' });
+
+        expect(mockUpdateLastActivity).not.toHaveBeenCalled();
+        expect(mockLogStorage.rotateLogs).not.toHaveBeenCalled();
+        expect(mockHandleSyncAlarm).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('Alarm Cleanup', () => {
+    it('should remove alarm listeners on service destruction', () => {
+      // Initialize service and get the listener
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+
+      // Destroy service
+      service.destroy();
+
+      if (alarmListener) {
+        expect(mockAlarms.onAlarm.removeListener).toHaveBeenCalledWith(alarmListener);
+      }
+    });
+
+    it('should clear sync alarm on service destruction', () => {
+      service.destroy();
+
+      expect(mockAlarms.clear).toHaveBeenCalledWith('bolt-project-sync');
+    });
+  });
+
+  describe('Keep-Alive Activity Tracking', () => {
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(1000000);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('should track last activity timestamp', () => {
+      (service as any).updateLastActivity();
+
+      expect((service as any).lastActivityTime).toBe(1000000);
+    });
+
+    it('should store keep-alive timestamp in chrome storage', () => {
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+
+      if (alarmListener) {
+        alarmListener({ name: 'keepAlive' });
+
+        expect(mockStorage.local.set).toHaveBeenCalledWith({
+          lastKeepAlive: 1000000,
+        });
+      }
+    });
+  });
+
+  describe('Connection Management', () => {
+    it('should initialize with empty ports map', () => {
+      expect((service as any).ports).toBeInstanceOf(Map);
+      expect((service as any).ports.size).toBe(0);
+    });
+
+    it('should manage port connections', () => {
+      const ports = (service as any).ports;
+
+      // Verify we can work with the ports Map
+      expect(ports.size).toBe(0);
+
+      // Note: Actual port management is handled by Chrome extension runtime
+      // and would require more complex mocking to test the connection handlers
+    });
+  });
+});

--- a/src/background/__tests__/BackgroundService.alarms.test.ts
+++ b/src/background/__tests__/BackgroundService.alarms.test.ts
@@ -186,16 +186,15 @@ describe('BackgroundService - Alarms Functionality', () => {
 
       // Get the alarm listener
       const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(alarmListener).toBeDefined();
 
-      if (alarmListener) {
-        // Trigger keep-alive alarm
-        alarmListener({ name: 'keepAlive' });
+      // Trigger keep-alive alarm
+      alarmListener({ name: 'keepAlive' });
 
-        expect(mockUpdateLastActivity).toHaveBeenCalled();
-        expect(mockStorage.local.set).toHaveBeenCalledWith({
-          lastKeepAlive: expect.any(Number),
-        });
-      }
+      expect(mockUpdateLastActivity).toHaveBeenCalled();
+      expect(mockStorage.local.set).toHaveBeenCalledWith({
+        lastKeepAlive: expect.any(Number),
+      });
     });
   });
 
@@ -204,6 +203,21 @@ describe('BackgroundService - Alarms Functionality', () => {
       await jest.runOnlyPendingTimersAsync();
 
       expect(mockAlarms.create).toHaveBeenCalledWith('bolt-project-sync', { periodInMinutes: 5 });
+    });
+  });
+
+  describe('Alarm Configuration Verification', () => {
+    it('should create all alarms with correct parameters on initialization', async () => {
+      await jest.runOnlyPendingTimersAsync();
+
+      // Verify all three alarms are created with exact parameters
+      expect(mockAlarms.create).toHaveBeenCalledWith('logRotation', { periodInMinutes: 180 });
+      expect(mockAlarms.create).toHaveBeenCalledWith('keepAlive', { periodInMinutes: 1 });
+      expect(mockAlarms.create).toHaveBeenCalledWith('bolt-project-sync', { periodInMinutes: 5 });
+
+      // Note: mockAlarms.create.toHaveBeenCalledTimes count may vary due to keep-alive calls
+      // The important part is that all required alarms are created with correct parameters
+      expect(mockAlarms.create.mock.calls.length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -219,16 +233,15 @@ describe('BackgroundService - Alarms Functionality', () => {
 
       // Get the alarm listener
       const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(alarmListener).toBeDefined();
 
-      if (alarmListener) {
-        // Trigger keep-alive alarm
-        alarmListener({ name: 'keepAlive' });
+      // Trigger keep-alive alarm
+      alarmListener({ name: 'keepAlive' });
 
-        expect(mockUpdateLastActivity).toHaveBeenCalled();
-        expect(mockStorage.local.set).toHaveBeenCalledWith({
-          lastKeepAlive: expect.any(Number),
-        });
-      }
+      expect(mockUpdateLastActivity).toHaveBeenCalled();
+      expect(mockStorage.local.set).toHaveBeenCalledWith({
+        lastKeepAlive: expect.any(Number),
+      });
     });
 
     it('should handle log rotation alarm events', () => {
@@ -237,13 +250,12 @@ describe('BackgroundService - Alarms Functionality', () => {
 
       // Get the alarm listener
       const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(alarmListener).toBeDefined();
 
-      if (alarmListener) {
-        // Trigger log rotation alarm
-        alarmListener({ name: 'logRotation' });
+      // Trigger log rotation alarm
+      alarmListener({ name: 'logRotation' });
 
-        expect(mockLogStorage.rotateLogs).toHaveBeenCalled();
-      }
+      expect(mockLogStorage.rotateLogs).toHaveBeenCalled();
     });
 
     it('should handle sync alarm events', () => {
@@ -253,13 +265,12 @@ describe('BackgroundService - Alarms Functionality', () => {
 
       // Get the alarm listener
       const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(alarmListener).toBeDefined();
 
-      if (alarmListener) {
-        // Trigger sync alarm
-        alarmListener({ name: 'bolt-project-sync' });
+      // Trigger sync alarm
+      alarmListener({ name: 'bolt-project-sync' });
 
-        expect(mockHandleSyncAlarm).toHaveBeenCalled();
-      }
+      expect(mockHandleSyncAlarm).toHaveBeenCalled();
     });
 
     it('should ignore unknown alarm events', () => {
@@ -273,15 +284,14 @@ describe('BackgroundService - Alarms Functionality', () => {
 
       // Get the alarm listener
       const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(alarmListener).toBeDefined();
 
-      if (alarmListener) {
-        // Trigger unknown alarm
-        alarmListener({ name: 'unknown-alarm' });
+      // Trigger unknown alarm
+      alarmListener({ name: 'unknown-alarm' });
 
-        expect(mockUpdateLastActivity).not.toHaveBeenCalled();
-        expect(mockLogStorage.rotateLogs).not.toHaveBeenCalled();
-        expect(mockHandleSyncAlarm).not.toHaveBeenCalled();
-      }
+      expect(mockUpdateLastActivity).not.toHaveBeenCalled();
+      expect(mockLogStorage.rotateLogs).not.toHaveBeenCalled();
+      expect(mockHandleSyncAlarm).not.toHaveBeenCalled();
     });
   });
 
@@ -289,13 +299,12 @@ describe('BackgroundService - Alarms Functionality', () => {
     it('should remove alarm listeners on service destruction', () => {
       // Initialize service and get the listener
       const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(alarmListener).toBeDefined();
 
       // Destroy service
       service.destroy();
 
-      if (alarmListener) {
-        expect(mockAlarms.onAlarm.removeListener).toHaveBeenCalledWith(alarmListener);
-      }
+      expect(mockAlarms.onAlarm.removeListener).toHaveBeenCalledWith(alarmListener);
     });
 
     it('should clear sync alarm on service destruction', () => {
@@ -322,14 +331,13 @@ describe('BackgroundService - Alarms Functionality', () => {
 
     it('should store keep-alive timestamp in chrome storage', () => {
       const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(alarmListener).toBeDefined();
 
-      if (alarmListener) {
-        alarmListener({ name: 'keepAlive' });
+      alarmListener({ name: 'keepAlive' });
 
-        expect(mockStorage.local.set).toHaveBeenCalledWith({
-          lastKeepAlive: 1000000,
-        });
-      }
+      expect(mockStorage.local.set).toHaveBeenCalledWith({
+        lastKeepAlive: 1000000,
+      });
     });
   });
 

--- a/src/background/__tests__/BackgroundService.alarms.test.ts
+++ b/src/background/__tests__/BackgroundService.alarms.test.ts
@@ -185,7 +185,8 @@ describe('BackgroundService - Alarms Functionality', () => {
       const mockUpdateLastActivity = jest.spyOn(service as any, 'updateLastActivity');
 
       // Get the alarm listener
-      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(mockAlarms.onAlarm.addListener).toHaveBeenCalled();
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0][0];
       expect(alarmListener).toBeDefined();
 
       // Trigger keep-alive alarm
@@ -215,9 +216,11 @@ describe('BackgroundService - Alarms Functionality', () => {
       expect(mockAlarms.create).toHaveBeenCalledWith('keepAlive', { periodInMinutes: 1 });
       expect(mockAlarms.create).toHaveBeenCalledWith('bolt-project-sync', { periodInMinutes: 5 });
 
-      // Note: mockAlarms.create.toHaveBeenCalledTimes count may vary due to keep-alive calls
-      // The important part is that all required alarms are created with correct parameters
-      expect(mockAlarms.create.mock.calls.length).toBeGreaterThanOrEqual(3);
+      // Verify specific alarms were created
+      const alarmNames = mockAlarms.create.mock.calls.map((call) => call[0]);
+      expect(alarmNames).toContain('logRotation');
+      expect(alarmNames).toContain('keepAlive');
+      expect(alarmNames).toContain('bolt-project-sync');
     });
   });
 
@@ -232,7 +235,8 @@ describe('BackgroundService - Alarms Functionality', () => {
       const mockUpdateLastActivity = jest.spyOn(service as any, 'updateLastActivity');
 
       // Get the alarm listener
-      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(mockAlarms.onAlarm.addListener).toHaveBeenCalled();
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0][0];
       expect(alarmListener).toBeDefined();
 
       // Trigger keep-alive alarm
@@ -249,7 +253,8 @@ describe('BackgroundService - Alarms Functionality', () => {
       mockLogStorage.rotateLogs.mockClear();
 
       // Get the alarm listener
-      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(mockAlarms.onAlarm.addListener).toHaveBeenCalled();
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0][0];
       expect(alarmListener).toBeDefined();
 
       // Trigger log rotation alarm
@@ -264,7 +269,8 @@ describe('BackgroundService - Alarms Functionality', () => {
         .mockImplementation();
 
       // Get the alarm listener
-      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(mockAlarms.onAlarm.addListener).toHaveBeenCalled();
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0][0];
       expect(alarmListener).toBeDefined();
 
       // Trigger sync alarm
@@ -283,7 +289,8 @@ describe('BackgroundService - Alarms Functionality', () => {
       mockLogStorage.rotateLogs.mockClear();
 
       // Get the alarm listener
-      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(mockAlarms.onAlarm.addListener).toHaveBeenCalled();
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0][0];
       expect(alarmListener).toBeDefined();
 
       // Trigger unknown alarm
@@ -298,7 +305,8 @@ describe('BackgroundService - Alarms Functionality', () => {
   describe('Alarm Cleanup', () => {
     it('should remove alarm listeners on service destruction', () => {
       // Initialize service and get the listener
-      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0]?.[0];
+      expect(mockAlarms.onAlarm.addListener).toHaveBeenCalled();
+      const alarmListener = mockAlarms.onAlarm.addListener.mock.calls[0][0];
       expect(alarmListener).toBeDefined();
 
       // Destroy service

--- a/src/lib/utils/__tests__/logStorage.test.ts
+++ b/src/lib/utils/__tests__/logStorage.test.ts
@@ -351,21 +351,30 @@ describe('LogStorageManager', () => {
       expect(mockChromeStorage.local.set).toHaveBeenCalled();
     });
 
-    it('should retain logs from the last 12 hours', async () => {
+    it('should retain logs based on 12 hours of activity, not just timestamp', async () => {
       const now = Date.now();
-      const elevenHoursAgo = new Date(now - 11 * 60 * 60 * 1000).toISOString();
-      const thirteenHoursAgo = new Date(now - 13 * 60 * 60 * 1000).toISOString();
+      const oneHourAgo = new Date(now - 1 * 60 * 60 * 1000).toISOString();
+      const fiveHoursAgo = new Date(now - 5 * 60 * 60 * 1000).toISOString();
+      const tenHoursAgo = new Date(now - 10 * 60 * 60 * 1000).toISOString();
+      const fifteenHoursAgo = new Date(now - 15 * 60 * 60 * 1000).toISOString();
 
-      // Add logs with different timestamps
-      await storageManager.addLog('info', 'OldModule', 'This should be removed');
-      await storageManager.addLog('info', 'RecentModule', 'This should be kept');
+      // Add logs representing different activity periods
+      await storageManager.addLog('info', 'RecentActivity', 'Recent log 1');
+      await storageManager.addLog('info', 'RecentActivity', 'Recent log 2');
+      await storageManager.addLog('info', 'MidActivity', 'Mid-activity log');
+      await storageManager.addLog('info', 'OldActivity', 'Within 12h activity span');
+      await storageManager.addLog('info', 'VeryOldActivity', 'Beyond 12h activity span');
 
       // Mock the timestamps in memory buffer
       const memoryBuffer = (storageManager as any).memoryBuffer;
-      memoryBuffer[0].timestamp = thirteenHoursAgo;
-      memoryBuffer[1].timestamp = elevenHoursAgo;
+      expect(memoryBuffer.length).toBe(5);
+      memoryBuffer[0].timestamp = oneHourAgo; // Recent
+      memoryBuffer[1].timestamp = fiveHoursAgo; // Recent
+      memoryBuffer[2].timestamp = tenHoursAgo; // Within 12h activity window
+      memoryBuffer[3].timestamp = tenHoursAgo; // Within 12h activity window (same time as previous)
+      memoryBuffer[4].timestamp = fifteenHoursAgo; // Beyond 12h activity window
 
-      // Mock storage to return empty initially
+      // Mock storage to return logs when getAllLogs is called
       mockChromeStorage.local.get.mockImplementation((keys: any, callback?: any) => {
         const result: any = {};
         if (keys === null) {
@@ -389,11 +398,18 @@ describe('LogStorageManager', () => {
       // Verify that set was called
       expect(mockChromeStorage.local.set).toHaveBeenCalled();
 
-      // The memory buffer should only contain the recent log
+      // The memory buffer should contain logs within the 12-hour activity window
+      // Since all logs from 1h to 10h ago span 9 hours of activity (< 12h), they should all be kept
+      // Only the 15h ago log should be removed as it extends the activity window beyond 12h
       const recentLogs = storageManager.getRecentLogs();
-      expect(recentLogs).toHaveLength(1);
-      expect(recentLogs[0].module).toBe('RecentModule');
-      expect(recentLogs[0].message).toBe('This should be kept');
+      expect(recentLogs.length).toBe(4);
+
+      // Verify the very old activity log was removed
+      const modules = recentLogs.map((log) => log.module);
+      expect(modules).toContain('RecentActivity');
+      expect(modules).toContain('MidActivity');
+      expect(modules).toContain('OldActivity');
+      expect(modules).not.toContain('VeryOldActivity');
     });
   });
 });

--- a/src/lib/utils/logStorage.ts
+++ b/src/lib/utils/logStorage.ts
@@ -202,6 +202,7 @@ export class LogStorageManager {
       if (!chrome.storage || !chrome.storage.local) return;
 
       const now = new Date();
+      const cutoffTime = new Date(now.getTime() - this.LOG_RETENTION_HOURS * 60 * 60 * 1000);
 
       // Get all log keys
       const allKeys = await this.getAllLogKeys();
@@ -217,19 +218,7 @@ export class LogStorageManager {
         });
       }
 
-      // Get ALL logs to determine activity-based retention
-      const allLogs = await this.getAllLogs();
-
-      // Sort by timestamp (newest first)
-      allLogs.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-
-      // Activity-based retention: Keep logs that represent 12 hours of actual logging activity
-      const retainedLogs = this.selectLogsForRetention(allLogs);
-      const retainedLogIds = new Set(
-        retainedLogs.map((log) => log.timestamp + log.module + log.message)
-      );
-
-      // Identify batches to remove
+      // Identify batches to remove based on simple time-based retention
       const batchesToRemove: string[] = [];
       for (const key of allKeys) {
         if (key === this.CURRENT_BATCH_KEY || key === this.METADATA_KEY) continue;
@@ -237,25 +226,23 @@ export class LogStorageManager {
         const batchResult = await chrome.storage.local.get(key);
         const batch = batchResult[key] as LogEntry[] | undefined;
         if (batch && batch.length > 0) {
-          // Check if any logs in this batch should be retained
-          const hasRetainedLogs = batch.some((log) =>
-            retainedLogIds.has(log.timestamp + log.module + log.message)
-          );
+          // Check if any logs in this batch are newer than cutoff time
+          const hasRecentLogs = batch.some((log) => new Date(log.timestamp) >= cutoffTime);
 
-          if (!hasRetainedLogs) {
+          if (!hasRecentLogs) {
             batchesToRemove.push(key);
           }
         }
       }
 
-      // Remove old batches that don't contain retained logs
+      // Remove old batches
       if (batchesToRemove.length > 0) {
         await chrome.storage.local.remove(batchesToRemove);
       }
 
-      // Clean up memory buffer (keep only retained logs)
-      this.memoryBuffer = this.memoryBuffer.filter((entry) =>
-        retainedLogIds.has(entry.timestamp + entry.module + entry.message)
+      // Clean up memory buffer (keep only recent logs)
+      this.memoryBuffer = this.memoryBuffer.filter(
+        (entry) => new Date(entry.timestamp) >= cutoffTime
       );
 
       // Update metadata with rotation timestamp
@@ -263,66 +250,6 @@ export class LogStorageManager {
     } catch (error) {
       console.error('Failed to rotate logs:', error);
     }
-  }
-
-  /**
-   * Select logs for retention based on activity, not just time
-   * Keeps the most recent 12 hours worth of actual logging activity
-   */
-  private selectLogsForRetention(allLogs: LogEntry[]): LogEntry[] {
-    if (allLogs.length === 0) return [];
-
-    // If we have fewer logs than the max limit, keep them all
-    if (allLogs.length <= this.MAX_LOG_ENTRIES) {
-      return this.filterByActivityWindow(allLogs);
-    }
-
-    // Otherwise, keep the most recent MAX_LOG_ENTRIES
-    const recentLogs = allLogs.slice(0, this.MAX_LOG_ENTRIES);
-    return this.filterByActivityWindow(recentLogs);
-  }
-
-  /**
-   * Filter logs to represent 12 hours of actual activity
-   */
-  private filterByActivityWindow(logs: LogEntry[]): LogEntry[] {
-    if (logs.length === 0) return [];
-
-    // Start with the newest log
-    const newestLog = logs[0];
-    const newestTime = new Date(newestLog.timestamp);
-
-    // Find logs that span 12 hours of actual logged activity
-    const activitySpanMs = this.LOG_RETENTION_HOURS * 60 * 60 * 1000; // 12 hours in ms
-    const retainedLogs: LogEntry[] = [];
-
-    let activityStartTime: Date | null = null;
-    const activityEndTime = newestTime;
-
-    for (const log of logs) {
-      const logTime = new Date(log.timestamp);
-
-      // Always keep the newest logs
-      if (!activityStartTime) {
-        activityStartTime = logTime;
-        retainedLogs.push(log);
-        continue;
-      }
-
-      // Calculate the actual time span of logging activity so far
-      const currentActivitySpan = activityEndTime.getTime() - logTime.getTime();
-
-      // If this log extends our activity window beyond 12 hours, stop here
-      if (currentActivitySpan > activitySpanMs) {
-        break;
-      }
-
-      // Keep this log as it's within our activity window
-      retainedLogs.push(log);
-      activityStartTime = logTime;
-    }
-
-    return retainedLogs;
   }
 
   private async getAllLogKeys(): Promise<string[]> {

--- a/src/lib/utils/logStorage.ts
+++ b/src/lib/utils/logStorage.ts
@@ -29,7 +29,7 @@ export class LogStorageManager {
   private readonly MAX_MEMORY_ENTRIES = 1000;
   private readonly MAX_BATCH_SIZE = 100;
   private readonly WRITE_INTERVAL = 10000; // 10 seconds
-  private readonly LOG_RETENTION_HOURS = 6;
+  private readonly LOG_RETENTION_HOURS = 12;
   private readonly STORAGE_KEY_PREFIX = 'bolt_logs_';
   private readonly CURRENT_BATCH_KEY = 'bolt_logs_current';
   private readonly METADATA_KEY = 'bolt_logs_metadata';

--- a/src/test/setup/chrome-mocks.js
+++ b/src/test/setup/chrome-mocks.js
@@ -111,13 +111,3 @@ global.chrome.tabs.sendMessage = jest.fn().mockImplementation((tabId, message, c
     return Promise.resolve({});
   }
 });
-
-// Mock chrome.alarms API
-global.chrome.alarms = {
-  create: jest.fn(),
-  clear: jest.fn(),
-  onAlarm: {
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-  },
-};


### PR DESCRIPTION
### **User description**
## Summary

This PR implements the fix for issue #125 (update bolt logs retention to 12 hours) and adds comprehensive test coverage for the Chrome alarms API functionality that was previously untested.

### 🔧 Changes Made

**Issue #125 - 12-Hour Log Retention:**
- ✅ Updated `LOG_RETENTION_HOURS` from 6 to 12 hours in LogStorageManager
- ✅ Updated log rotation alarm to check every 3 hours (180 minutes) for logs older than 12 hours
- ✅ Added comprehensive test coverage for the 12-hour retention policy

**Chrome Alarms API Testing:**
- ✅ Created `BackgroundService.alarms.test.ts` with full alarm functionality tests
- ✅ Fixed inconsistent `chrome.alarms` mock definitions in `chrome-mocks.js`
- ✅ Added test coverage for keep-alive, log rotation, and sync alarm behaviors
- ✅ Tested alarm event handling, cleanup, and edge cases
- ✅ Verified proper integration between alarms and LogStorageManager

### 🧪 Test Coverage Added

- **Log Rotation Alarm Tests**: Verify 3-hour interval creation and event handling
- **Keep-Alive Alarm Tests**: Test 1-minute interval for service worker persistence
- **Sync Alarm Tests**: Validate 5-minute project synchronization intervals
- **Alarm Event Handler Tests**: Ensure proper routing of different alarm types
- **Alarm Cleanup Tests**: Verify proper removal of listeners on service destruction
- **Activity Tracking Tests**: Test last activity timestamp updates and Chrome storage

### 🔄 Alarm Behavior Analysis

**Chrome Open/Close Scenario:**
- When Chrome closes after 1 hour, then reopens 4 hours later:
  - ✅ All alarms persist and resume from their persisted schedule
  - ✅ Log rotation will run within the next 3-hour window (may have missed one cycle)
  - ✅ Keep-alive and sync alarms resume immediately
  - ✅ Unlike `setInterval`, Chrome alarms survive browser restarts

**Alarm Types:**
- **Log Rotation**: Every 3 hours, cleans logs older than 12 hours
- **Keep-Alive**: Every 1 minute, maintains service worker activity
- **Sync**: Every 5 minutes, synchronizes bolt projects

### ✅ Verification

- [x] All existing tests pass
- [x] New alarm tests pass (18 new test cases)
- [x] Lint warnings: exactly 7 (as required)
- [x] Zero TypeScript errors (`pnpm check`)
- [x] Successful production build
- [x] Follows unit testing rules for behavior-focused testing

## Test Plan

1. **Log Retention**: Verify logs are kept for 12 hours and cleaned up appropriately
2. **Alarm Persistence**: Test that alarms continue working across browser restarts
3. **Event Handling**: Confirm alarm events trigger correct handler functions
4. **Cleanup**: Ensure alarm listeners are properly removed on service destruction

Fixes #125


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Update log retention from 6 to 12 hours

- Replace setInterval with Chrome alarms for reliability

- Add comprehensive Chrome alarms API test coverage

- Fix inconsistent alarm mock definitions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BackgroundService.ts</strong><dd><code>Switch log rotation to Chrome alarms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/background/BackgroundService.ts

<li>Replace setInterval with chrome.alarms.create for log rotation<br> <li> Change rotation check interval from 6 hours to 3 hours (180 minutes)<br> <li> Remove JavaScript timer approach in favor of Chrome alarms API


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/140/files#diff-c6c6a7488dbcc7a9ee2285757501a92a23ab27e8694ff5b0378d5dfb3fafa98f">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logStorage.ts</strong><dd><code>Update log retention period to 12 hours</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/utils/logStorage.ts

- Change `LOG_RETENTION_HOURS` constant from 6 to 12 hours


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/140/files#diff-aeda22177d83f24d0407a20c67de7373930837db3620cd7361bc939d005ed51d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BackgroundService.alarms.test.ts</strong><dd><code>Add Chrome alarms comprehensive test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/background/__tests__/BackgroundService.alarms.test.ts

<li>Add comprehensive test suite for Chrome alarms functionality<br> <li> Test log rotation, keep-alive, and sync alarm behaviors<br> <li> Cover alarm event handling, cleanup, and edge cases<br> <li> Mock Chrome APIs with enhanced alarm functionality


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/140/files#diff-2271afaf1167f7d5079427abd6d949bf522a63fc7a611d79fbfb7f8d638418d0">+352/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logStorage.test.ts</strong><dd><code>Update log retention tests for 12-hour policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/utils/__tests__/logStorage.test.ts

<li>Update test timestamps from 7 hours to 13 hours for old logs<br> <li> Add specific test for 12-hour retention policy verification<br> <li> Test that logs older than 12 hours are removed while recent ones are <br>kept


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/140/files#diff-930c0cfe617143c9215229691b407e78ebbf44d43527d01e6f8aefb2be614ddb">+46/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome-mocks.js</strong><dd><code>Fix inconsistent Chrome alarms mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/setup/chrome-mocks.js

<li>Remove inconsistent chrome.alarms mock definition<br> <li> Clean up duplicate alarm API mocking


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/bolt-to-github/pull/140/files#diff-cf695065d0736f76786c461d8f21d2e981bb4eb06c71b8221d51be33a341c051">+0/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>