### PR TITLE
fix: comprehensive auth lifecycle recovery for MV3 service worker

### DIFF
--- a/src/background/BackgroundService.ts
+++ b/src/background/BackgroundService.ts
@@ -54,8 +54,10 @@ export class BackgroundService {
   private initialAuthCheckCompleted: boolean = false;
   // Track delayed sync timeout for cancellation
   private delayedSyncTimeout: NodeJS.Timeout | null = null;
-  // Prevent concurrent sync operations
+  // Prevent concurrent sync operations (with auto-reset to avoid stuck state after SW restart)
   private syncInProgress: boolean = false;
+  private syncStartedAt: number = 0;
+  private readonly SYNC_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes max sync duration
 
   constructor() {
     logger.info('🚀 Background service initializing...');
@@ -1878,6 +1880,10 @@ export class BackgroundService {
         this.rotateOldLogs();
       } else if (alarm.name === 'bolt-project-sync') {
         this.handleSyncAlarm();
+      } else if (alarm.name === 'auth-periodic-check') {
+        // Handle periodic auth check alarm (survives service worker termination)
+        logger.info('🔐 Auth periodic check alarm triggered');
+        this.supabaseAuthService.forceCheck();
       } else if (alarm.name === 'self-heal-reload') {
         // Handle extension reload for authentication self-healing
         logger.info('🔄 Self-heal alarm triggered - reloading extension now...');
@@ -1896,12 +1902,25 @@ export class BackgroundService {
    * Safely perform inward sync with concurrency protection
    */
   private async safePerformInwardSync(context: string): Promise<void> {
+    // Auto-reset stuck syncInProgress flag (e.g. if service worker restarted mid-sync)
+    if (this.syncInProgress && this.syncStartedAt > 0) {
+      const elapsed = Date.now() - this.syncStartedAt;
+      if (elapsed > this.SYNC_TIMEOUT_MS) {
+        logger.warn(
+          `⚠️ Sync has been in progress for ${Math.round(elapsed / 1000)}s — resetting stuck flag`
+        );
+        this.syncInProgress = false;
+        this.syncStartedAt = 0;
+      }
+    }
+
     if (this.syncInProgress) {
       logger.info(`⏸️ Sync already in progress, skipping ${context} sync request`);
       return;
     }
 
     this.syncInProgress = true;
+    this.syncStartedAt = Date.now();
     logger.info(`🔄 Starting ${context} inward sync`);
 
     try {
@@ -1911,6 +1930,7 @@ export class BackgroundService {
       logger.error(`💥 ${context} inward sync failed:`, error);
     } finally {
       this.syncInProgress = false;
+      this.syncStartedAt = 0;
     }
   }
 

--- a/src/background/__tests__/BackgroundService.auth-lifecycle.test.ts
+++ b/src/background/__tests__/BackgroundService.auth-lifecycle.test.ts
@@ -1,0 +1,235 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackgroundService } from '../BackgroundService';
+
+vi.mock('../../services/UnifiedGitHubService');
+vi.mock('../../services/zipHandler');
+vi.mock('../StateManager', () => ({
+  StateManager: {
+    getInstance: vi.fn(() => ({
+      getGitHubSettings: vi.fn().mockResolvedValue({ gitHubSettings: {} }),
+    })),
+  },
+}));
+vi.mock('../TempRepoManager');
+
+const mockForceCheck = vi.fn();
+
+vi.mock('../../content/services/SupabaseAuthService', () => ({
+  SupabaseAuthService: {
+    getInstance: vi.fn(() => ({
+      forceCheck: mockForceCheck,
+      getAuthState: vi.fn().mockReturnValue({ isAuthenticated: true }),
+      addAuthStateListener: vi.fn(),
+      removeAuthStateListener: vi.fn(),
+      isPremium: vi.fn().mockReturnValue(false),
+    })),
+  },
+}));
+vi.mock('../../content/services/OperationStateManager', () => ({
+  OperationStateManager: {
+    getInstance: vi.fn(() => ({})),
+  },
+}));
+vi.mock('../../lib/utils/logger', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+  getLogStorage: vi.fn(() => ({
+    getLogs: vi.fn().mockResolvedValue([]),
+    rotateLogs: vi.fn(),
+  })),
+}));
+vi.mock('../UsageTracker', () => ({
+  UsageTracker: vi.fn(() => ({
+    initializeUsageData: vi.fn().mockResolvedValue(undefined),
+    updateUsageStats: vi.fn().mockResolvedValue(undefined),
+    trackError: vi.fn().mockResolvedValue(undefined),
+    setUninstallURL: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+vi.mock('../WindowManager', () => ({
+  WindowManager: {
+    getInstance: vi.fn(() => ({
+      openPopupWindow: vi.fn(),
+      closePopupWindow: vi.fn(),
+    })),
+  },
+}));
+
+const mockPerformOutwardSync = vi.fn().mockResolvedValue(null);
+const mockPerformInwardSync = vi.fn().mockResolvedValue(null);
+
+vi.mock('../../services/BoltProjectSyncService', () => ({
+  BoltProjectSyncService: vi.fn(() => ({
+    performOutwardSync: mockPerformOutwardSync,
+    performInwardSync: mockPerformInwardSync,
+  })),
+}));
+
+const createChromeAPIMock = () => {
+  const alarmListeners: ((alarm: chrome.alarms.Alarm) => void)[] = [];
+
+  return {
+    alarms: {
+      create: vi.fn(),
+      clear: vi.fn(),
+      onAlarm: {
+        addListener: vi.fn((handler) => alarmListeners.push(handler)),
+        removeListener: vi.fn((handler) => {
+          const index = alarmListeners.indexOf(handler);
+          if (index !== -1) alarmListeners.splice(index, 1);
+        }),
+      },
+      _triggerAlarm: (alarm: chrome.alarms.Alarm) => {
+        alarmListeners.forEach((listener) => listener(alarm));
+      },
+    },
+    storage: {
+      local: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      sync: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      },
+    },
+    runtime: {
+      onInstalled: { addListener: vi.fn() },
+      onConnect: { addListener: vi.fn() },
+      onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+      onStartup: { addListener: vi.fn() },
+      lastError: null,
+      getManifest: vi.fn(() => ({ version: '1.0.0' })),
+      sendMessage: vi.fn(),
+      reload: vi.fn(),
+    },
+    tabs: {
+      get: vi.fn(),
+      onUpdated: { addListener: vi.fn() },
+      onRemoved: { addListener: vi.fn() },
+      onActivated: { addListener: vi.fn() },
+      query: vi.fn().mockResolvedValue([]),
+      create: vi.fn(),
+      sendMessage: vi.fn(),
+    },
+    action: {
+      openPopup: vi.fn(),
+    },
+  };
+};
+
+describe('BackgroundService - Auth Lifecycle Recovery', () => {
+  let chromeMock: ReturnType<typeof createChromeAPIMock>;
+  let service: BackgroundService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    chromeMock = createChromeAPIMock();
+    global.chrome = chromeMock as any;
+
+    service = new BackgroundService();
+  });
+
+  afterEach(() => {
+    service.destroy();
+    vi.useRealTimers();
+  });
+
+  describe('syncInProgress timeout auto-reset', () => {
+    it('should reset stuck syncInProgress flag after SYNC_TIMEOUT_MS', async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Simulate a stuck sync: set flag + old timestamp
+      (service as any).syncInProgress = true;
+      (service as any).syncStartedAt = Date.now() - 6 * 60 * 1000; // 6 minutes ago
+
+      mockPerformInwardSync.mockClear();
+      mockPerformInwardSync.mockResolvedValue(null);
+
+      // This should detect the stale flag and reset it, then proceed
+      await (service as any).safePerformInwardSync('test');
+
+      expect(mockPerformInwardSync).toHaveBeenCalled();
+    });
+
+    it('should not reset syncInProgress if within timeout', async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Simulate an ongoing sync that's only 1 minute old
+      (service as any).syncInProgress = true;
+      (service as any).syncStartedAt = Date.now() - 60 * 1000; // 1 minute ago
+
+      mockPerformInwardSync.mockClear();
+
+      await (service as any).safePerformInwardSync('test');
+
+      // Should skip because sync is still in progress (within timeout)
+      expect(mockPerformInwardSync).not.toHaveBeenCalled();
+    });
+
+    it('should reset syncStartedAt after sync completes', async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+
+      mockPerformInwardSync.mockClear();
+      mockPerformInwardSync.mockResolvedValue(null);
+
+      await (service as any).safePerformInwardSync('test');
+
+      expect((service as any).syncInProgress).toBe(false);
+      expect((service as any).syncStartedAt).toBe(0);
+    });
+
+    it('should reset syncStartedAt even if sync fails', async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+
+      mockPerformInwardSync.mockClear();
+      mockPerformInwardSync.mockRejectedValue(new Error('Sync error'));
+
+      await (service as any).safePerformInwardSync('test');
+
+      expect((service as any).syncInProgress).toBe(false);
+      expect((service as any).syncStartedAt).toBe(0);
+    });
+  });
+
+  describe('auth-periodic-check alarm handler', () => {
+    it('should call supabaseAuthService.forceCheck when auth alarm fires', async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+
+      mockForceCheck.mockClear();
+
+      chromeMock.alarms._triggerAlarm({
+        name: 'auth-periodic-check',
+      } as chrome.alarms.Alarm);
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(mockForceCheck).toHaveBeenCalled();
+    });
+
+    it('should not call forceCheck for unrelated alarms', async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+
+      mockForceCheck.mockClear();
+
+      chromeMock.alarms._triggerAlarm({ name: 'keepAlive' } as chrome.alarms.Alarm);
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      // forceCheck should NOT have been called by keepAlive alarm
+      // (it may have been called during initialization, but we cleared the mock)
+      expect(mockForceCheck).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/content/services/SupabaseAuthService.ts
+++ b/src/content/services/SupabaseAuthService.ts
@@ -71,6 +71,10 @@ export class SupabaseAuthService {
   private postConnectionStartTime: number = 0;
   private aggressiveDetectionInterval: number | null = null;
 
+  /* Guards against duplicate Chrome event listener registration */
+  private initialAuthDetectionSetup: boolean = false;
+  private subscriptionDetectionSetup: boolean = false;
+
   /* Extension reload tracking for self-healing */
   private consecutiveAuthFailures: number = 0;
   private lastReloadTimestamp: number = 0;
@@ -171,16 +175,24 @@ export class SupabaseAuthService {
   }
 
   /**
-   * Start periodic authentication checks with aggressive detection during onboarding
+   * Start periodic authentication checks with aggressive detection during onboarding.
+   *
+   * Uses chrome.alarms for long-running intervals (authenticated/premium modes)
+   * since they survive service worker termination in MV3. Falls back to setInterval
+   * for short aggressive detection modes (1-2s) where alarms aren't practical
+   * (chrome.alarms minimum is 1 minute) and the modes only last ~60 seconds anyway.
    */
   private startPeriodicChecks(): void {
+    /* Clear any existing interval timer */
     if (this.checkInterval) {
       clearInterval(this.checkInterval);
+      this.checkInterval = null;
     }
 
     /* Use different intervals based on authentication and subscription status */
     let interval: number;
     let mode: string;
+    let useAlarm = false;
 
     if (!this.authState.isAuthenticated) {
       /* Check if we're in post-connection aggressive mode */
@@ -218,13 +230,38 @@ export class SupabaseAuthService {
         interval = this.CHECK_INTERVAL_AUTHENTICATED;
         mode = 'authenticated';
       }
+      /* Use chrome.alarms for long-running authenticated modes (survives SW termination) */
+      useAlarm = true;
     }
 
-    this.checkInterval = setInterval(() => {
-      this.checkAuthStatus();
-    }, interval);
-
-    logger.info(`🔄 Started auth checks every ${interval / 1000}s (${mode})`);
+    if (useAlarm) {
+      /* chrome.alarms survives service worker termination — reliable for long intervals.
+       * The alarm handler in BackgroundService.setupAlarms() dispatches to checkAuthStatus(). */
+      const periodInMinutes = Math.max(interval / 60000, 1); // chrome.alarms minimum is 1 minute
+      try {
+        chrome.alarms?.create?.('auth-periodic-check', { periodInMinutes });
+        logger.info(
+          `🔄 Started auth checks via chrome.alarms every ${periodInMinutes}min (${mode})`
+        );
+      } catch {
+        /* Fallback to setInterval if alarms API unavailable (e.g. content script context) */
+        this.checkInterval = setInterval(() => {
+          this.checkAuthStatus();
+        }, interval);
+        logger.info(`🔄 Started auth checks via setInterval every ${interval / 1000}s (${mode})`);
+      }
+    } else {
+      /* Short intervals for aggressive detection — setInterval is fine for these
+       * since they only last ~60 seconds and the service worker stays alive during active use */
+      this.checkInterval = setInterval(() => {
+        this.checkAuthStatus();
+      }, interval);
+      /* Clear the alarm if we're switching to short-interval mode */
+      chrome.alarms?.clear?.('auth-periodic-check')?.catch?.(() => {
+        /* Alarm might not exist — ignore */
+      });
+      logger.info(`🔄 Started auth checks every ${interval / 1000}s (${mode})`);
+    }
   }
 
   /**
@@ -303,6 +340,15 @@ export class SupabaseAuthService {
         logger.info('🔐 User already authenticated, skipping initial auth detection');
         return;
       }
+
+      /* Prevent duplicate Chrome event listener registration.
+       * Chrome listeners accumulate — they cannot be removed without a reference,
+       * and re-calling addListener adds another copy. */
+      if (this.initialAuthDetectionSetup) {
+        logger.info('🔐 Initial auth detection listeners already registered, skipping');
+        return;
+      }
+      this.initialAuthDetectionSetup = true;
 
       logger.info('🔍 Setting up enhanced initial authentication detection for bolt2github.com');
 
@@ -401,6 +447,13 @@ export class SupabaseAuthService {
    */
   private setupSubscriptionUpgradeDetection(): void {
     try {
+      /* Prevent duplicate Chrome event listener registration */
+      if (this.subscriptionDetectionSetup) {
+        logger.info('💰 Subscription detection listeners already registered, skipping');
+        return;
+      }
+      this.subscriptionDetectionSetup = true;
+
       /* Only listen for specific upgrade/billing related pages */
       chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
         /* Only check if user is authenticated and on upgrade/billing pages */
@@ -1134,9 +1187,10 @@ export class SupabaseAuthService {
           created_at: user.created_at,
           updated_at: user.updated_at,
         };
-      } else if (response.status === 403) {
+      } else if (response.status === 401 || response.status === 403) {
+        /* Supabase can return either 401 or 403 for expired/invalid tokens */
         const errorData = await response.json().catch(() => ({}));
-        logger.warn('🔐 Token verification failed (403):', errorData);
+        logger.warn(`🔐 Token verification failed (${response.status}):`, errorData);
 
         /* Check if session is completely invalidated (user logged out) */
         if (errorData.error_code === 'session_not_found') {
@@ -1146,7 +1200,12 @@ export class SupabaseAuthService {
         }
 
         /* Check if it's an expired token error that can be refreshed */
-        if (errorData.error_code === 'bad_jwt' || errorData.msg?.includes('expired')) {
+        if (
+          errorData.error_code === 'bad_jwt' ||
+          errorData.msg?.includes('expired') ||
+          errorData.error_description?.includes('expired') ||
+          response.status === 401
+        ) {
           logger.info('🔄 Token expired, attempting to refresh...');
           const refreshedToken = await this.refreshStoredToken();
           if (refreshedToken) {
@@ -1220,9 +1279,9 @@ export class SupabaseAuthService {
           subscriptionId: undefined /* Not provided in this response */,
           customerId: undefined /* Not provided in this response */,
         };
-      } else if (response.status === 403) {
+      } else if (response.status === 401 || response.status === 403) {
         const errorData = await response.json().catch(() => ({}));
-        logger.warn('🔐 Subscription check failed (403):', errorData);
+        logger.warn(`🔐 Subscription check failed (${response.status}):`, errorData);
 
         /* Check if session is completely invalidated */
         if (errorData.error_code === 'session_not_found') {
@@ -1232,7 +1291,12 @@ export class SupabaseAuthService {
         }
 
         /* Check if it's an expired token error that can be refreshed */
-        if (errorData.error_code === 'bad_jwt' || errorData.msg?.includes('expired')) {
+        if (
+          errorData.error_code === 'bad_jwt' ||
+          errorData.msg?.includes('expired') ||
+          errorData.error_description?.includes('expired') ||
+          response.status === 401
+        ) {
           logger.info('🔄 Token expired during subscription check, attempting to refresh...');
           const refreshedToken = await this.refreshStoredToken();
           if (refreshedToken) {
@@ -1545,12 +1609,21 @@ export class SupabaseAuthService {
       this.checkInterval = null;
     }
 
+    /* Clear the auth alarm if active */
+    chrome.alarms?.clear?.('auth-periodic-check')?.catch?.(() => {
+      /* Alarm might not exist — ignore */
+    });
+
     this.stopAggressiveDetection();
 
     /* Reset aggressive detection state */
     this.isInitialOnboarding = true;
     this.isPostConnectionMode = false;
     this.postConnectionStartTime = 0;
+
+    /* Reset listener guards so they can be re-registered after cleanup */
+    this.initialAuthDetectionSetup = false;
+    this.subscriptionDetectionSetup = false;
 
     /* Reset failure counter and reload flag (but preserve reload timestamp to prevent loops) */
     this.consecutiveAuthFailures = 0;

--- a/src/content/services/SupabaseAuthService.ts
+++ b/src/content/services/SupabaseAuthService.ts
@@ -650,6 +650,7 @@ export class SupabaseAuthService {
         'supabaseToken',
         'supabaseRefreshToken',
         'supabaseTokenExpiry',
+        'refreshTokenIssuedAt', // Track when refresh token was issued
       ]);
 
       if (!storedTokens.supabaseToken) {
@@ -665,6 +666,28 @@ export class SupabaseAuthService {
         logger.info('✅ Using stored access token (valid)');
         return storedTokens.supabaseToken;
       } else if (storedTokens.supabaseRefreshToken) {
+        /* Check if refresh token might be too old (Supabase refresh tokens expire after ~30 days of inactivity) */
+        const refreshTokenAge = storedTokens.refreshTokenIssuedAt
+          ? now - storedTokens.refreshTokenIssuedAt
+          : 0;
+        const REFRESH_TOKEN_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+        if (refreshTokenAge > REFRESH_TOKEN_MAX_AGE) {
+          logger.warn(
+            `🕐 Refresh token is very old (${Math.round(
+              refreshTokenAge / (24 * 60 * 60 * 1000)
+            )} days). Likely expired. Clearing tokens to force re-authentication.`
+          );
+          /* Clear tokens immediately if refresh token is too old */
+          await chrome.storage.local.remove([
+            'supabaseToken',
+            'supabaseRefreshToken',
+            'supabaseTokenExpiry',
+            'refreshTokenIssuedAt',
+          ]);
+          return null;
+        }
+
         /* Token expired or expires soon, try to refresh */
         logger.info('🔄 Stored token expired/expiring, refreshing...');
         return await this.refreshStoredToken();
@@ -694,6 +717,8 @@ export class SupabaseAuthService {
       /* Only store refresh token if it exists and is not empty */
       if (tokenData.refresh_token && tokenData.refresh_token.trim() !== '') {
         storageData.supabaseRefreshToken = tokenData.refresh_token;
+        /* Track when refresh token was issued to detect expired refresh tokens */
+        storageData.refreshTokenIssuedAt = Date.now();
         logger.info('💾 Storing refresh token (length:', tokenData.refresh_token.length, ')');
       } else {
         logger.error('⚠️ No valid refresh token to store');
@@ -996,7 +1021,10 @@ export class SupabaseAuthService {
    */
   private async refreshStoredToken(): Promise<string | null> {
     try {
-      const result = await chrome.storage.local.get(['supabaseRefreshToken']);
+      const result = await chrome.storage.local.get([
+        'supabaseRefreshToken',
+        'refreshTokenIssuedAt',
+      ]);
       const refreshToken = result.supabaseRefreshToken;
 
       if (!refreshToken) {
@@ -1005,7 +1033,14 @@ export class SupabaseAuthService {
       }
 
       logger.info('🔄 Attempting to refresh stored token...');
-      return await this.performTokenRefresh(refreshToken);
+      const refreshedToken = await this.performTokenRefresh(refreshToken);
+
+      /* If refresh was successful, update the refresh token issue timestamp */
+      if (refreshedToken) {
+        await chrome.storage.local.set({ refreshTokenIssuedAt: Date.now() });
+      }
+
+      return refreshedToken;
     } catch (error) {
       logger.error('❌ Error refreshing stored token:', error);
       return null;
@@ -1048,11 +1083,24 @@ export class SupabaseAuthService {
         const errorData = await response.json().catch(() => ({}));
         logger.warn('❌ Token refresh failed:', response.status, errorData);
 
+        /* Check if refresh token itself is expired or invalid */
+        const isRefreshTokenExpired =
+          response.status === 400 && errorData.error_description?.includes('refresh');
+        const isInvalidGrant =
+          errorData.error === 'invalid_grant' || errorData.error_description?.includes('invalid');
+
+        if (isRefreshTokenExpired || isInvalidGrant) {
+          logger.error(
+            '🕐 Refresh token is expired or invalid. Both access and refresh tokens need re-authentication.'
+          );
+        }
+
         /* If refresh failed, clear stored tokens */
         await chrome.storage.local.remove([
           'supabaseToken',
           'supabaseRefreshToken',
           'supabaseTokenExpiry',
+          'refreshTokenIssuedAt',
         ]);
         return null;
       }
@@ -1205,8 +1253,19 @@ export class SupabaseAuthService {
    * Handle session invalidation by clearing tokens and showing re-auth modal
    */
   private async handleSessionInvalidation(): Promise<void> {
-    /* Clear all stored tokens since session is invalid */
-    await this.clearStoredTokens();
+    /* Clear all stored tokens including refresh token issue date */
+    await chrome.storage.local.remove([
+      'supabaseToken',
+      'supabaseRefreshToken',
+      'supabaseTokenExpiry',
+      'refreshTokenIssuedAt',
+    ]);
+    /* Reset internal auth state */
+    this.authState = {
+      isAuthenticated: false,
+      user: null,
+      subscription: { isActive: false, plan: 'free' },
+    };
     /* Show re-authentication modal */
     await this.showReauthenticationModal();
   }
@@ -1431,6 +1490,7 @@ export class SupabaseAuthService {
         'supabaseRefreshToken',
         'supabaseTokenExpiry',
         'supabaseAuthState',
+        'refreshTokenIssuedAt',
       ]);
 
       /* Reset internal auth state */

--- a/src/content/services/SupabaseAuthService.ts
+++ b/src/content/services/SupabaseAuthService.ts
@@ -234,32 +234,24 @@ export class SupabaseAuthService {
       useAlarm = true;
     }
 
-    if (useAlarm) {
+    if (useAlarm && typeof chrome.alarms?.create === 'function') {
       /* chrome.alarms survives service worker termination — reliable for long intervals.
        * The alarm handler in BackgroundService.setupAlarms() dispatches to checkAuthStatus(). */
       const periodInMinutes = Math.max(interval / 60000, 1); // chrome.alarms minimum is 1 minute
-      try {
-        chrome.alarms?.create?.('auth-periodic-check', { periodInMinutes });
-        logger.info(
-          `🔄 Started auth checks via chrome.alarms every ${periodInMinutes}min (${mode})`
-        );
-      } catch {
-        /* Fallback to setInterval if alarms API unavailable (e.g. content script context) */
-        this.checkInterval = setInterval(() => {
-          this.checkAuthStatus();
-        }, interval);
-        logger.info(`🔄 Started auth checks via setInterval every ${interval / 1000}s (${mode})`);
-      }
+      chrome.alarms.create('auth-periodic-check', { periodInMinutes });
+      logger.info(`🔄 Started auth checks via chrome.alarms every ${periodInMinutes}min (${mode})`);
     } else {
-      /* Short intervals for aggressive detection — setInterval is fine for these
-       * since they only last ~60 seconds and the service worker stays alive during active use */
+      /* Fallback to setInterval when alarms API is unavailable or for short-interval modes.
+       * Short intervals for aggressive detection only last ~60s and don't need alarm persistence. */
       this.checkInterval = setInterval(() => {
         this.checkAuthStatus();
       }, interval);
-      /* Clear the alarm if we're switching to short-interval mode */
-      chrome.alarms?.clear?.('auth-periodic-check')?.catch?.(() => {
-        /* Alarm might not exist — ignore */
-      });
+      /* Clear any existing alarm when switching to setInterval mode */
+      if (typeof chrome.alarms?.clear === 'function') {
+        chrome.alarms.clear('auth-periodic-check').catch(() => {
+          /* Alarm might not exist — ignore */
+        });
+      }
       logger.info(`🔄 Started auth checks every ${interval / 1000}s (${mode})`);
     }
   }
@@ -1317,19 +1309,15 @@ export class SupabaseAuthService {
    * Handle session invalidation by clearing tokens and showing re-auth modal
    */
   private async handleSessionInvalidation(): Promise<void> {
-    /* Clear all stored tokens including refresh token issue date */
-    await chrome.storage.local.remove([
-      'supabaseToken',
-      'supabaseRefreshToken',
-      'supabaseTokenExpiry',
-      'refreshTokenIssuedAt',
-    ]);
-    /* Reset internal auth state */
-    this.authState = {
+    /* Clear all stored tokens (reuses clearStoredTokens to avoid key list duplication) */
+    await this.clearStoredTokens();
+    /* Notify listeners and persist auth state via updateAuthState (not direct mutation)
+     * so that storage, premium service, and periodic-check reconfiguration all update */
+    this.updateAuthState({
       isAuthenticated: false,
       user: null,
       subscription: { isActive: false, plan: 'free' },
-    };
+    });
     /* Show re-authentication modal */
     await this.showReauthenticationModal();
   }
@@ -1610,9 +1598,11 @@ export class SupabaseAuthService {
     }
 
     /* Clear the auth alarm if active */
-    chrome.alarms?.clear?.('auth-periodic-check')?.catch?.(() => {
-      /* Alarm might not exist — ignore */
-    });
+    if (typeof chrome.alarms?.clear === 'function') {
+      chrome.alarms.clear('auth-periodic-check').catch(() => {
+        /* Alarm might not exist — ignore */
+      });
+    }
 
     this.stopAggressiveDetection();
 

--- a/src/content/services/__tests__/SupabaseAuthService.auth-recovery.test.ts
+++ b/src/content/services/__tests__/SupabaseAuthService.auth-recovery.test.ts
@@ -1,0 +1,364 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockChromeRuntime = {
+  id: 'test-extension-id',
+  sendMessage: vi.fn().mockResolvedValue({ success: true }),
+  reload: vi.fn(),
+};
+
+const mockChromeStorage = {
+  local: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  },
+  sync: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+  },
+  onChanged: {
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  },
+};
+
+const mockChromeTabs = {
+  query: vi.fn().mockResolvedValue([]),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  onUpdated: {
+    addListener: vi.fn(),
+  },
+  onActivated: {
+    addListener: vi.fn(),
+  },
+};
+
+const mockChromeAlarms = {
+  create: vi.fn(),
+  clear: vi.fn().mockResolvedValue(true),
+  onAlarm: {
+    addListener: vi.fn(),
+  },
+};
+
+const mockChromeScripting = {
+  executeScript: vi.fn().mockResolvedValue([]),
+};
+
+global.chrome = {
+  runtime: mockChromeRuntime,
+  storage: mockChromeStorage,
+  tabs: mockChromeTabs,
+  alarms: mockChromeAlarms,
+  scripting: mockChromeScripting,
+} as any;
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+import { SupabaseAuthService } from '../SupabaseAuthService';
+
+describe('SupabaseAuthService - Auth Recovery (401/403, alarms, listener guards)', () => {
+  let authService: SupabaseAuthService;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date('2024-06-15T12:00:00.000Z') });
+    vi.clearAllMocks();
+
+    (SupabaseAuthService as any).instance = null;
+    authService = SupabaseAuthService.getInstance();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    authService.cleanup();
+  });
+
+  describe('401 handling in verifyTokenAndGetUser', () => {
+    test('should attempt token refresh on 401 response', async () => {
+      const refreshSpy = vi.spyOn(authService as any, 'refreshStoredToken').mockResolvedValue(null);
+
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'unauthorized' }),
+      });
+
+      const result = await (authService as any).verifyTokenAndGetUser('expired-token');
+
+      expect(result).toBeNull();
+      expect(refreshSpy).toHaveBeenCalled();
+    });
+
+    test('should retry verification with refreshed token on 401', async () => {
+      const refreshSpy = vi
+        .spyOn(authService as any, 'refreshStoredToken')
+        .mockResolvedValueOnce('fresh-token');
+
+      // First call: 401
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'unauthorized' }),
+      });
+      // Second call (retry with fresh token): success
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: 'user-123',
+            email: 'test@example.com',
+            created_at: '2024-01-01',
+            updated_at: '2024-01-01',
+          }),
+      });
+
+      const result = await (authService as any).verifyTokenAndGetUser('expired-token');
+
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(result).not.toBeNull();
+      expect(result.email).toBe('test@example.com');
+    });
+
+    test('should handle session_not_found on 401 by invalidating session', async () => {
+      const handleInvalidationSpy = vi
+        .spyOn(authService as any, 'handleSessionInvalidation')
+        .mockResolvedValue(undefined);
+
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error_code: 'session_not_found' }),
+      });
+
+      const result = await (authService as any).verifyTokenAndGetUser('some-token');
+
+      expect(result).toBeNull();
+      expect(handleInvalidationSpy).toHaveBeenCalled();
+    });
+
+    test('should attempt refresh on 403 with bad_jwt error', async () => {
+      const refreshSpy = vi.spyOn(authService as any, 'refreshStoredToken').mockResolvedValue(null);
+
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ error_code: 'bad_jwt' }),
+      });
+
+      await (authService as any).verifyTokenAndGetUser('expired-token');
+
+      expect(refreshSpy).toHaveBeenCalled();
+    });
+
+    test('should attempt refresh on 403 with expired message', async () => {
+      const refreshSpy = vi.spyOn(authService as any, 'refreshStoredToken').mockResolvedValue(null);
+
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: () =>
+          Promise.resolve({ error_description: 'Token has expired, please re-authenticate' }),
+      });
+
+      await (authService as any).verifyTokenAndGetUser('expired-token');
+
+      expect(refreshSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('401 handling in getSubscriptionStatus', () => {
+    test('should attempt token refresh on 401 response during subscription check', async () => {
+      const refreshSpy = vi.spyOn(authService as any, 'refreshStoredToken').mockResolvedValue(null);
+
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'unauthorized' }),
+      });
+
+      const user = { id: 'u1', email: 'a@b.c', created_at: '', updated_at: '' };
+      const result = await (authService as any).getSubscriptionStatus('expired-token', user);
+
+      expect(result).toEqual({ isActive: false, plan: 'free' });
+      expect(refreshSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Duplicate listener registration guards', () => {
+    test('should only register initial auth detection listeners once', () => {
+      const addListenerCalls = mockChromeTabs.onUpdated.addListener.mock.calls.length;
+
+      // Force non-authenticated state
+      (authService as any).authState.isAuthenticated = false;
+      (authService as any).initialAuthDetectionSetup = false;
+
+      (authService as any).setupInitialAuthDetection();
+      const afterFirst = mockChromeTabs.onUpdated.addListener.mock.calls.length;
+
+      (authService as any).setupInitialAuthDetection();
+      const afterSecond = mockChromeTabs.onUpdated.addListener.mock.calls.length;
+
+      // Second call should NOT add more listeners
+      expect(afterSecond - addListenerCalls).toBe(afterFirst - addListenerCalls);
+    });
+
+    test('should only register subscription detection listeners once', () => {
+      const addListenerCalls = mockChromeTabs.onUpdated.addListener.mock.calls.length;
+
+      (authService as any).subscriptionDetectionSetup = false;
+
+      (authService as any).setupSubscriptionUpgradeDetection();
+      const afterFirst = mockChromeTabs.onUpdated.addListener.mock.calls.length;
+
+      (authService as any).setupSubscriptionUpgradeDetection();
+      const afterSecond = mockChromeTabs.onUpdated.addListener.mock.calls.length;
+
+      expect(afterSecond - addListenerCalls).toBe(afterFirst - addListenerCalls);
+    });
+
+    test('cleanup should reset listener guards allowing re-registration', () => {
+      (authService as any).initialAuthDetectionSetup = true;
+      (authService as any).subscriptionDetectionSetup = true;
+
+      authService.cleanup();
+
+      expect((authService as any).initialAuthDetectionSetup).toBe(false);
+      expect((authService as any).subscriptionDetectionSetup).toBe(false);
+    });
+  });
+
+  describe('Chrome alarms for periodic auth checks', () => {
+    test('should use chrome.alarms for authenticated mode', () => {
+      mockChromeAlarms.create.mockClear();
+
+      (authService as any).authState.isAuthenticated = true;
+      (authService as any).authState.subscription = { isActive: false, plan: 'free' };
+
+      (authService as any).startPeriodicChecks();
+
+      expect(mockChromeAlarms.create).toHaveBeenCalledWith('auth-periodic-check', {
+        periodInMinutes: expect.any(Number),
+      });
+    });
+
+    test('should use chrome.alarms for premium mode', () => {
+      mockChromeAlarms.create.mockClear();
+
+      (authService as any).authState.isAuthenticated = true;
+      (authService as any).authState.subscription = { isActive: true, plan: 'monthly' };
+
+      (authService as any).startPeriodicChecks();
+
+      expect(mockChromeAlarms.create).toHaveBeenCalledWith('auth-periodic-check', {
+        periodInMinutes: expect.any(Number),
+      });
+    });
+
+    test('should use setInterval for unauthenticated short-interval modes', () => {
+      mockChromeAlarms.create.mockClear();
+
+      (authService as any).authState.isAuthenticated = false;
+      (authService as any).isInitialOnboarding = true;
+
+      (authService as any).startPeriodicChecks();
+
+      // Should NOT create an alarm for short-interval mode
+      expect(mockChromeAlarms.create).not.toHaveBeenCalledWith(
+        'auth-periodic-check',
+        expect.anything()
+      );
+      // Should have a setInterval active
+      expect((authService as any).checkInterval).not.toBeNull();
+    });
+
+    test('should clear alarm when switching to short-interval mode', () => {
+      mockChromeAlarms.clear.mockClear();
+
+      (authService as any).authState.isAuthenticated = false;
+      (authService as any).isInitialOnboarding = false;
+      (authService as any).isPostConnectionMode = false;
+
+      (authService as any).startPeriodicChecks();
+
+      expect(mockChromeAlarms.clear).toHaveBeenCalledWith('auth-periodic-check');
+    });
+
+    test('cleanup should clear auth alarm', () => {
+      mockChromeAlarms.clear.mockClear();
+
+      authService.cleanup();
+
+      expect(mockChromeAlarms.clear).toHaveBeenCalledWith('auth-periodic-check');
+    });
+  });
+
+  describe('30-day refresh token validation', () => {
+    test('should return null when refresh token is older than 30 days', async () => {
+      const now = Date.now();
+      const thirtyOneDaysAgo = now - 31 * 24 * 60 * 60 * 1000;
+
+      mockChromeStorage.local.get.mockResolvedValueOnce({
+        supabaseToken: 'expired-access-token',
+        supabaseRefreshToken: 'old-refresh-token',
+        supabaseTokenExpiry: now - 1000, // expired
+        refreshTokenIssuedAt: thirtyOneDaysAgo,
+      });
+
+      const result = await (authService as any).getValidStoredToken();
+
+      expect(result).toBeNull();
+      // Should clear tokens
+      expect(mockChromeStorage.local.remove).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          'supabaseToken',
+          'supabaseRefreshToken',
+          'supabaseTokenExpiry',
+          'refreshTokenIssuedAt',
+        ])
+      );
+    });
+
+    test('should attempt refresh when token is within 30-day window', async () => {
+      const now = Date.now();
+      const twentyDaysAgo = now - 20 * 24 * 60 * 60 * 1000;
+
+      mockChromeStorage.local.get.mockResolvedValueOnce({
+        supabaseToken: 'expired-access-token',
+        supabaseRefreshToken: 'valid-refresh-token',
+        supabaseTokenExpiry: now - 1000, // expired
+        refreshTokenIssuedAt: twentyDaysAgo,
+      });
+
+      const refreshSpy = vi
+        .spyOn(authService as any, 'refreshStoredToken')
+        .mockResolvedValue('new-token');
+
+      const result = await (authService as any).getValidStoredToken();
+
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(result).toBe('new-token');
+    });
+
+    test('should store refreshTokenIssuedAt when storing token data', async () => {
+      mockChromeStorage.local.set.mockClear();
+
+      await (authService as any).storeTokenData({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      });
+
+      expect(mockChromeStorage.local.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          supabaseToken: 'new-access',
+          supabaseRefreshToken: 'new-refresh',
+          refreshTokenIssuedAt: expect.any(Number),
+        })
+      );
+    });
+  });
+});

--- a/src/content/services/__tests__/SupabaseAuthService.reload.test.ts
+++ b/src/content/services/__tests__/SupabaseAuthService.reload.test.ts
@@ -37,6 +37,7 @@ const mockChromeTabs = {
 
 const mockChromeAlarms = {
   create: vi.fn(),
+  clear: vi.fn().mockResolvedValue(true),
   onAlarm: {
     addListener: vi.fn(),
   },

--- a/src/services/GitHubAppService.ts
+++ b/src/services/GitHubAppService.ts
@@ -3,15 +3,15 @@
  * Communicates with Supabase Edge Functions for OAuth flow and token management
  */
 
-import type {
-  GitHubAppConfig,
-  GitHubAppTokenResponse,
-  GitHubAppErrorResponse,
-  TokenValidationResult,
-  PermissionCheckResult,
-} from './types/authentication';
 import { SUPABASE_CONFIG } from '../lib/constants/supabase';
 import { createLogger } from '../lib/utils/logger';
+import type {
+  GitHubAppConfig,
+  GitHubAppErrorResponse,
+  GitHubAppTokenResponse,
+  PermissionCheckResult,
+  TokenValidationResult,
+} from './types/authentication';
 
 const logger = createLogger('GitHubAppService');
 
@@ -41,15 +41,59 @@ export class GitHubAppService {
     // Try to extract from Supabase auth storage
     try {
       const authKey = `sb-${SUPABASE_CONFIG.URL.split('//')[1].split('.')[0]}-auth-token`;
-      const result = await chrome.storage.local.get(authKey);
+      const result = await chrome.storage.local.get([
+        authKey,
+        'supabaseToken',
+        'supabaseTokenExpiry',
+        'refreshTokenIssuedAt',
+      ]);
       const authData = result[authKey];
 
       if (authData?.access_token) {
+        // Check if the Supabase token might be expired
+        const tokenExpiry = result.supabaseTokenExpiry || 0;
+        const now = Date.now();
+
+        // If token is expired, check refresh token age
+        if (tokenExpiry < now) {
+          // If refreshTokenIssuedAt is missing, we can't determine token age
+          // This happens for existing users before the fix was deployed
+          // In this case, let it through but log a warning - SupabaseAuthService will handle validation
+          if (!result.refreshTokenIssuedAt) {
+            logger.warn(
+              '⚠️ Supabase token is expired and refresh token age is unknown (legacy installation). ' +
+                'Allowing through - SupabaseAuthService will validate and trigger re-auth if needed.'
+            );
+          } else {
+            const refreshTokenAge = now - result.refreshTokenIssuedAt;
+            const REFRESH_TOKEN_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+            if (refreshTokenAge > REFRESH_TOKEN_MAX_AGE) {
+              logger.warn(
+                `🕐 Supabase refresh token is very old (${Math.round(
+                  refreshTokenAge / (24 * 60 * 60 * 1000)
+                )} days). GitHub operations will likely fail. User needs to re-authenticate.`
+              );
+              throw new Error(
+                'Supabase authentication expired. Please re-authenticate via bolt2github.com.'
+              );
+            }
+
+            logger.warn(
+              '⚠️ Supabase token is expired but refresh token might work. Attempting to use it anyway.'
+            );
+          }
+        }
+
         this.userToken = authData.access_token;
         return authData.access_token;
       }
     } catch (error) {
       logger.error('Failed to get user token from storage:', error);
+      // Re-throw the error if it's our custom expiration error
+      if (error instanceof Error && error.message.includes('Supabase authentication expired')) {
+        throw error;
+      }
     }
 
     throw new Error('No user token available. Please authenticate with bolt2github.com first.');

--- a/src/services/GitHubAppService.ts
+++ b/src/services/GitHubAppService.ts
@@ -31,9 +31,12 @@ export class GitHubAppService {
   }
 
   /**
-   * Get the user token, extracting from Supabase auth if needed
+   * Get the user token, extracting from Supabase auth if needed.
+   * Always reads fresh from storage to avoid using stale tokens after
+   * service worker restarts or token refreshes by SupabaseAuthService.
    */
   private async getUserToken(): Promise<string> {
+    // If explicitly set via setUserToken(), use it (short-lived caller context)
     if (this.userToken) {
       return this.userToken;
     }
@@ -47,24 +50,21 @@ export class GitHubAppService {
         'supabaseTokenExpiry',
         'refreshTokenIssuedAt',
       ]);
+
+      const now = Date.now();
+      const tokenExpiry = result.supabaseTokenExpiry || 0;
+
+      // Prefer the managed supabaseToken (refreshed by SupabaseAuthService) if it's still valid
+      if (result.supabaseToken && tokenExpiry > now + 60 * 1000) {
+        return result.supabaseToken;
+      }
+
+      // Fall back to the Supabase auth-key token
       const authData = result[authKey];
-
       if (authData?.access_token) {
-        // Check if the Supabase token might be expired
-        const tokenExpiry = result.supabaseTokenExpiry || 0;
-        const now = Date.now();
-
-        // If token is expired, check refresh token age
-        if (tokenExpiry < now) {
-          // If refreshTokenIssuedAt is missing, we can't determine token age
-          // This happens for existing users before the fix was deployed
-          // In this case, let it through but log a warning - SupabaseAuthService will handle validation
-          if (!result.refreshTokenIssuedAt) {
-            logger.warn(
-              '⚠️ Supabase token is expired and refresh token age is unknown (legacy installation). ' +
-                'Allowing through - SupabaseAuthService will validate and trigger re-auth if needed.'
-            );
-          } else {
+        // If token is expired, check refresh token age before using
+        if (tokenExpiry > 0 && tokenExpiry < now) {
+          if (result.refreshTokenIssuedAt) {
             const refreshTokenAge = now - result.refreshTokenIssuedAt;
             const REFRESH_TOKEN_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
 
@@ -72,20 +72,21 @@ export class GitHubAppService {
               logger.warn(
                 `🕐 Supabase refresh token is very old (${Math.round(
                   refreshTokenAge / (24 * 60 * 60 * 1000)
-                )} days). GitHub operations will likely fail. User needs to re-authenticate.`
+                )} days). User needs to re-authenticate.`
               );
               throw new Error(
                 'Supabase authentication expired. Please re-authenticate via bolt2github.com.'
               );
             }
-
-            logger.warn(
-              '⚠️ Supabase token is expired but refresh token might work. Attempting to use it anyway.'
-            );
           }
+
+          logger.warn(
+            '⚠️ Supabase token is expired but refresh token might work. ' +
+              'Allowing through - SupabaseAuthService will handle refresh.'
+          );
         }
 
-        this.userToken = authData.access_token;
+        // Do NOT cache in this.userToken — always read fresh from storage
         return authData.access_token;
       }
     } catch (error) {

--- a/src/services/__tests__/GitHubAppService.token-validation.test.ts
+++ b/src/services/__tests__/GitHubAppService.token-validation.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  setupGitHubAppServiceTest,
+  FIXED_TIME,
+  type GitHubAppServiceTestEnvironment,
+} from './test-fixtures';
+
+describe('GitHubAppService - Token Validation & Expiry', () => {
+  let env: GitHubAppServiceTestEnvironment;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: FIXED_TIME });
+    env = setupGitHubAppServiceTest({
+      useRealService: true,
+      withSupabaseToken: true,
+    });
+  });
+
+  afterEach(() => {
+    env.cleanup();
+    vi.useRealTimers();
+  });
+
+  describe('getUserToken expiry validation', () => {
+    it('should prefer managed supabaseToken when valid', async () => {
+      const authKey = `sb-gapvjcqybzabnrjnxzhg-auth-token`;
+      env.storage.set({
+        [authKey]: {
+          access_token: 'old_auth_key_token',
+        },
+        supabaseToken: 'fresh_managed_token',
+        supabaseTokenExpiry: FIXED_TIME + 5 * 60 * 1000, // expires in 5 min
+      });
+
+      const token = await (env.service as any).getUserToken();
+      expect(token).toBe('fresh_managed_token');
+    });
+
+    it('should fall back to auth-key token when supabaseToken is expired', async () => {
+      const authKey = `sb-gapvjcqybzabnrjnxzhg-auth-token`;
+      env.storage.set({
+        [authKey]: {
+          access_token: 'auth_key_token',
+        },
+        supabaseToken: 'expired_managed_token',
+        supabaseTokenExpiry: FIXED_TIME - 1000, // already expired
+        refreshTokenIssuedAt: FIXED_TIME - 5 * 24 * 60 * 60 * 1000, // 5 days ago (within 30d)
+      });
+
+      const token = await (env.service as any).getUserToken();
+      expect(token).toBe('auth_key_token');
+    });
+
+    it('should throw when refresh token is older than 30 days', async () => {
+      const authKey = `sb-gapvjcqybzabnrjnxzhg-auth-token`;
+      env.storage.set({
+        [authKey]: {
+          access_token: 'some_token',
+        },
+        supabaseToken: 'expired_token',
+        supabaseTokenExpiry: FIXED_TIME - 1000, // expired
+        refreshTokenIssuedAt: FIXED_TIME - 31 * 24 * 60 * 60 * 1000, // 31 days ago
+      });
+
+      await expect((env.service as any).getUserToken()).rejects.toThrow(
+        'Supabase authentication expired'
+      );
+    });
+
+    it('should allow through when refreshTokenIssuedAt is missing (legacy)', async () => {
+      const authKey = `sb-gapvjcqybzabnrjnxzhg-auth-token`;
+      env.storage.set({
+        [authKey]: {
+          access_token: 'legacy_token',
+        },
+        supabaseToken: 'expired_token',
+        supabaseTokenExpiry: FIXED_TIME - 1000, // expired
+        // No refreshTokenIssuedAt — legacy installation
+      });
+
+      const token = await (env.service as any).getUserToken();
+      expect(token).toBe('legacy_token');
+    });
+
+    it('should not cache userToken in instance (always read fresh)', async () => {
+      const authKey = `sb-gapvjcqybzabnrjnxzhg-auth-token`;
+      env.storage.set({
+        [authKey]: {
+          access_token: 'first_token',
+        },
+        supabaseToken: 'first_managed_token',
+        supabaseTokenExpiry: FIXED_TIME + 5 * 60 * 1000,
+      });
+
+      const token1 = await (env.service as any).getUserToken();
+      expect(token1).toBe('first_managed_token');
+
+      // Update storage with a new token (simulating SupabaseAuthService refresh)
+      env.storage.set({
+        supabaseToken: 'refreshed_managed_token',
+        supabaseTokenExpiry: FIXED_TIME + 60 * 60 * 1000,
+      });
+
+      const token2 = await (env.service as any).getUserToken();
+      expect(token2).toBe('refreshed_managed_token');
+    });
+
+    it('should throw when no tokens are available', async () => {
+      env.storage.clear();
+
+      await expect((env.service as any).getUserToken()).rejects.toThrow('No user token available');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the persistent authentication failure after inactivity that required manually toggling the extension off/on in `chrome://extensions` to recover. This was caused by multiple layered failures in the auth chain that compounded each other.

### Root causes identified and fixed:

- **30-day Supabase refresh token expiry undetected** — refresh tokens expire after ~30 days of inactivity but the extension never checked the token's age before attempting a refresh, causing a silent cascade failure through GitHubAppService → GitHubAppAuthenticationStrategy → push failure
- **401 responses not handled** — `verifyTokenAndGetUser` and `getSubscriptionStatus` only handled 403 responses, but Supabase can also return 401 for expired/invalid tokens. 401 responses fell through without attempting a refresh
- **Stale Supabase token cached in GitHubAppService** — `this.userToken` was cached in-memory permanently; after SupabaseAuthService refreshed the token, GitHubAppService continued using the old expired one
- **`syncInProgress` stuck after service worker restart** — MV3 service workers terminate after ~30s of inactivity. If terminated mid-sync, `syncInProgress` flag stayed `true` in the new instance, blocking all future sync operations forever
- **Duplicate Chrome event listeners accumulating** — `setupInitialAuthDetection()` was re-called on every auth→unauth transition, adding duplicate `chrome.tabs.onUpdated` listeners each time
- **`setInterval` auth checks lost on service worker termination** — periodic auth checks used `setInterval` which doesn't survive MV3 service worker termination; authenticated users could go hours without an auth check after the worker restarted

### Changes:

| File | Change |
|------|--------|
| `SupabaseAuthService.ts` | Track `refreshTokenIssuedAt`, validate 30-day limit, handle 401+403, use `chrome.alarms` for long-interval auth checks, guard duplicate listeners |
| `GitHubAppService.ts` | Always read fresh token from storage (don't cache), prefer managed `supabaseToken`, validate token expiry before use |
| `BackgroundService.ts` | Add `syncInProgress` timeout auto-reset (5min), handle `auth-periodic-check` alarm |
| `SupabaseAuthService.reload.test.ts` | Add `clear` to alarm mock for compatibility |

### Tests added:
- `SupabaseAuthService.auth-recovery.test.ts` — 17 tests (401 handling, listener guards, alarm usage, 30-day validation)
- `BackgroundService.auth-lifecycle.test.ts` — 6 tests (sync timeout reset, auth alarm handler)
- `GitHubAppService.token-validation.test.ts` — 6 tests (token expiry, fresh reads, 30-day rejection)

## Test plan

- [x] All 4137 tests pass (168 test files)
- [x] ESLint clean
- [x] TypeScript type check clean (svelte-check 0 errors)
- [x] Production build succeeds
- [ ] Manual test: install extension, authenticate via bolt2github.com, leave idle for >30 min, verify push still works without toggle
- [ ] Manual test: verify re-authentication flow triggers correctly when tokens are truly expired