### PR TITLE
ci: pin pnpm to 10 and bump Node to 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
           run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Set version


### PR DESCRIPTION
## Summary

- The `Create Release` workflow uses `pnpm/action-setup@v4` with `version: latest`, which now resolves to pnpm@11.0.8.
- pnpm@11 requires Node.js >= 22.13, but the workflow pinned `node-version: '20'`.
- Result: the v1.3.17 tag push failed during pnpm bootstrap with `Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite`.

## Fix

- Pin `pnpm/action-setup@v4` to `version: 10` (matches local dev `pnpm 10.29.3` and the lockfile generation environment).
- Bump `actions/setup-node@v4` to `node-version: '22'` (current LTS).

This keeps the CI toolchain reproducible without floating to the next pnpm major.

## Test plan

- [ ] After merge, trigger `Create Release` workflow via `workflow_dispatch` with version `v1.3.17`.
- [ ] Confirm the workflow installs deps, builds, zips, and publishes the GitHub release with `bolt-to-github-v1.3.17.zip` attached.

## Follow-up (separate PR)

- Address the 45 Dependabot advisories on `dev-v1.3.18` via `pnpm update`, scoped overrides for stubborn transitive vulns, and reviewed major bumps.