### PR TITLE
ci: bump GitHub Actions to Node 24 compatible majors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -59,7 +59,7 @@ jobs:
           zip -r ../bolt-to-github-${{ env.VERSION }}.zip .
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: bolt-to-github-${{ env.VERSION }}.zip
           draft: false


### PR DESCRIPTION
## Summary

Clears the GitHub Actions Node 20 deprecation warning surfaced on the v1.3.17 release run. Starting June 2, 2026 runners default to Node 24, and Node 20 is removed from runners on September 16, 2026.

## Changes

| Action | Old | New | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | release.yml, claude.yml, claude-code-review.yml |
| `actions/setup-node` | v4 | v5 | release.yml |
| `pnpm/action-setup` | v4 | v5 | release.yml |
| `softprops/action-gh-release` | v1 | v2 | release.yml |

Inputs unchanged. Stops one major short of the absolute latest (v6 / v3) to keep the bump on battle-tested releases while still clearing the deprecation.

## Test plan

- [ ] After merge, trigger `Create Release` via `workflow_dispatch` against `dev-v1.3.18` with input `manual-build` to validate the build/zip pipeline before the next real release tag (intentionally avoiding a real tag here).
- [ ] If `softprops/action-gh-release@v2` rejects the `manual-build` ref, cancel the run and confirm the workflow at least progresses past install/build/zip.
- [ ] Validate via the next real `v1.3.18` tag push that the full release pipeline succeeds end to end.

## Risk

Low. The GHA majors covered here have all been stable for over a year. Any breakage shows up immediately on the next workflow run, and the diff is one-line-per-action so a revert is trivial.