### PR TITLE
release: v1.3.21

### DIFF
--- a/.maid/plan-locks/align-e2e-auth-with-live-connection-gate.lock.json
+++ b/.maid/plan-locks/align-e2e-auth-with-live-connection-gate.lock.json
@@ -1,0 +1,111 @@
+{
+  "manifest_path": "manifests/align-e2e-auth-with-live-connection-gate.manifest.yaml",
+  "manifest_hash": "sha256:4514d965eb0a4da2b9463729f95f7c47e5a74dcdf21df99f50434b8c5d272a9d",
+  "test_hashes": {
+    "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:407c18bebfea921a7877825349ed2ca751ea1b662576b1074ac2f6b6b732f409"
+  },
+  "created_at": "2026-07-13T01:12:43.885322+00:00",
+  "revision": 4,
+  "revisions": [
+    {
+      "prior_manifest_hash": "sha256:c290fdf6542351cffb70fafaf335e7f0163df6ad70bb881702ca7f7f4c860045",
+      "prior_test_hashes": {
+        "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:7b23b0d19adb4483fde692d0b9b6626b49adad62a0f36bcf064c92b7e4a6235f"
+      },
+      "revised_at": "2026-07-13T01:17:01.916770+00:00",
+      "reason": "Pin live PAT username validation route for push scenarios",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:c290fdf6542351cffb70fafaf335e7f0163df6ad70bb881702ca7f7f4c860045",
+      "prior_test_hashes": {
+        "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:4497a0d8b09ecd32db0a7e64949c7db02b4e00bca7fe254f9f7d27f96abaf451"
+      },
+      "revised_at": "2026-07-13T02:09:54.168989+00:00",
+      "reason": "Capture reviewed completed Outcome evidence",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:4514d965eb0a4da2b9463729f95f7c47e5a74dcdf21df99f50434b8c5d272a9d",
+      "prior_test_hashes": {
+        "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:4497a0d8b09ecd32db0a7e64949c7db02b4e00bca7fe254f9f7d27f96abaf451"
+      },
+      "revised_at": "2026-07-13T02:19:33.431968+00:00",
+      "reason": "Refresh behavioral test hash after pre-commit formatting",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    }
+  ],
+  "red_evidence": {
+    "red": true,
+    "captured_at": "2026-07-13T01:17:16.016228+00:00",
+    "commands": [
+      {
+        "command": "pnpm exec vitest run src/test/e2e-helpers/popup-helpers.test.ts",
+        "exit_code": 1,
+        "output_tail": "+     await clickPushButton(page);\n+\n+     const retryError = await waitForErrorNotification(page);\n+     expect(retryError.toLowerCase()).toMatch(/failed|error|no.*content|not.*bolt/);\n+\n+     await page.close();\n+   });\n+ });\n+\n\n \u276f src/test/e2e-helpers/popup-helpers.test.ts:72:27\n     70|     expect(seedProductAuth).not.toContain(\"authenticationMethod: 'gith\u2026\n     71|     expect(seedProductAuth).not.toContain('githubAppInstallationId');\n     72|     expect(errorFlowSpec).toContain(\"context.route('https://api.github\u2026\n       |                           ^\n     73|   });\n     74| \n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n",
+        "classification": "red"
+      },
+      {
+        "command": "pnpm lint",
+        "exit_code": 0,
+        "output_tail": "\n> bolt-to-github@1.3.21 lint /home/atomrem/projects/codefrost-dev/bolt-to-github\n> eslint \"src/**/*.{js,ts,svelte}\"\n",
+        "classification": "not_red"
+      },
+      {
+        "command": "pnpm check",
+        "exit_code": 0,
+        "output_tail": "\n> bolt-to-github@1.3.21 check /home/atomrem/projects/codefrost-dev/bolt-to-github\n> svelte-check --tsconfig ./tsconfig.json\n\n\n====================================\nLoading svelte-check in workspace: /home/atomrem/projects/codefrost-dev/bolt-to-github\nGetting Svelte diagnostics...\n\n====================================\nsvelte-check found 0 errors and 0 warnings",
+        "classification": "not_red"
+      }
+    ]
+  },
+  "agent": null,
+  "_manifest_contract": {
+    "artifacts": [
+      "src/test/e2e-helpers/popup-helpers.test.ts:pins PAT onboarding validation to the current submit control",
+      "src/test/e2e-helpers/popup-helpers.test.ts:pins PAT onboarding validation to the current submit control:kind=test_function",
+      "src/test/e2e-helpers/popup-helpers.test.ts:seeds product error flows through a live PAT connection",
+      "src/test/e2e-helpers/popup-helpers.test.ts:seeds product error flows through a live PAT connection:kind=test_function"
+    ],
+    "files": {
+      "create": [],
+      "edit": ["src/test/e2e-helpers/popup-helpers.test.ts"],
+      "read": [
+        "e2e/helpers/popup.ts",
+        "e2e/helpers/storage.ts",
+        "manifests/gate-github-actions-on-live-connection.manifest.yaml",
+        "src/lib/utils/githubConnection.ts"
+      ]
+    },
+    "test_files": ["src/test/e2e-helpers/popup-helpers.test.ts"],
+    "validate_commands": [
+      "pnpm exec vitest run src/test/e2e-helpers/popup-helpers.test.ts",
+      "pnpm lint",
+      "pnpm check"
+    ]
+  }
+}

--- a/.maid/plan-locks/preserve-stored-session-recovery.lock.json
+++ b/.maid/plan-locks/preserve-stored-session-recovery.lock.json
@@ -1,0 +1,170 @@
+{
+  "manifest_path": "manifests/preserve-stored-session-recovery.manifest.yaml",
+  "manifest_hash": "sha256:6afc8a9391308625134ed82bec0476226109c5b67849bcfb21e1fc0847bb4b50",
+  "test_hashes": {
+    "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+    "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+    "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:c718ea793b4a0d1e3421354cc88f03cd52343a46cfdaad77702a39728cc35a83"
+  },
+  "created_at": "2026-07-13T01:52:32.979159+00:00",
+  "revision": 6,
+  "revisions": [
+    {
+      "prior_manifest_hash": "sha256:9d61e9bc20b2f146f1eb36c1c1ffb67c91da01fc7acf9bd6724146b8fd7c40c5",
+      "prior_test_hashes": {
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:8af6b319ddecfb48a14c3a42b2c21b1aec495a1d091101f7e5d0508dc4e8aa2e"
+      },
+      "revised_at": "2026-07-13T02:03:28.972233+00:00",
+      "reason": "Require overlapping stored-session checks to share one guided recovery side effect",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [
+          "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:opens only one recovery tab when stored-session checks overlap",
+          "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:opens only one recovery tab when stored-session checks overlap:kind=test_function"
+        ],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:9bb365d4237ad48dcf6d7bc9ddeffdf25240fa441b025687239f25e0a81cb1c6",
+      "prior_test_hashes": {
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:c718ea793b4a0d1e3421354cc88f03cd52343a46cfdaad77702a39728cc35a83"
+      },
+      "revised_at": "2026-07-13T02:04:42.472373+00:00",
+      "reason": "Protect the existing rapid-failure reload threshold while narrowing stored-session recovery deduplication",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": ["read:src/content/services/__tests__/SupabaseAuthService.reload.test.ts"],
+        "files_removed": [],
+        "validate_commands_added": [
+          "pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts src/content/services/__tests__/SupabaseAuthService.reload.test.ts"
+        ],
+        "validate_commands_removed": [
+          "pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts"
+        ]
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:7470fe8e6238efac40722025908a2d72b836c8fa2058811926f9d1aa538909af",
+      "prior_test_hashes": {
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:c718ea793b4a0d1e3421354cc88f03cd52343a46cfdaad77702a39728cc35a83"
+      },
+      "revised_at": "2026-07-13T02:09:54.483309+00:00",
+      "reason": "Capture reviewed completed Outcome evidence",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:6afc8a9391308625134ed82bec0476226109c5b67849bcfb21e1fc0847bb4b50",
+      "prior_test_hashes": {
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:c718ea793b4a0d1e3421354cc88f03cd52343a46cfdaad77702a39728cc35a83"
+      },
+      "revised_at": "2026-07-13T02:15:02.028924+00:00",
+      "reason": "Recapture red evidence against the expanded auth and reload validation command",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:6afc8a9391308625134ed82bec0476226109c5b67849bcfb21e1fc0847bb4b50",
+      "prior_test_hashes": {
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:c718ea793b4a0d1e3421354cc88f03cd52343a46cfdaad77702a39728cc35a83"
+      },
+      "revised_at": "2026-07-13T02:19:34.382483+00:00",
+      "reason": "Refresh behavioral test hash after pre-commit formatting",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    }
+  ],
+  "red_evidence": {
+    "red": true,
+    "captured_at": "2026-07-13T02:15:16.139799+00:00",
+    "commands": [
+      {
+        "command": "pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+        "exit_code": 1,
+        "output_tail": "     62| \n     63|     expect(chrome.tabs.create).toHaveBeenCalledWith({\n       |                                ^\n     64|       url: 'https://bolt2github.com/login',\n     65|       active: true,\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/2]\u23af\n\n FAIL  src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts > SupabaseAuthService - fresh installation > opens only one recovery tab when stored-session checks overlap\nAssertionError: expected \"spy\" to be called 1 times, but got 0 times\n \u276f src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:99:32\n     97|     await Promise.all([authService.forceCheck(), authService.forceChec\u2026\n     98| \n     99|     expect(chrome.tabs.create).toHaveBeenCalledTimes(1);\n       |                                ^\n    100|     expect(chrome.tabs.create).toHaveBeenCalledWith({\n    101|       url: 'https://bolt2github.com/login',\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[2/2]\u23af\n",
+        "classification": "red"
+      },
+      {
+        "command": "pnpm lint",
+        "exit_code": 0,
+        "output_tail": "\n> bolt-to-github@1.3.20 lint /home/atomrem/projects/codefrost-dev/bolt-to-github\n> eslint \"src/**/*.{js,ts,svelte}\"\n",
+        "classification": "not_red"
+      },
+      {
+        "command": "pnpm check",
+        "exit_code": 0,
+        "output_tail": "\n> bolt-to-github@1.3.20 check /home/atomrem/projects/codefrost-dev/bolt-to-github\n> svelte-check --tsconfig ./tsconfig.json\n\n\n====================================\nLoading svelte-check in workspace: /home/atomrem/projects/codefrost-dev/bolt-to-github\nGetting Svelte diagnostics...\n\n====================================\nsvelte-check found 0 errors and 0 warnings",
+        "classification": "not_red"
+      }
+    ]
+  },
+  "agent": null,
+  "_manifest_contract": {
+    "artifacts": [
+      "src/content/services/SupabaseAuthService.ts:class:SupabaseAuthService",
+      "src/content/services/SupabaseAuthService.ts:class:SupabaseAuthService:kind=class",
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:opens only one recovery tab when stored-session checks overlap",
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:opens only one recovery tab when stored-session checks overlap:kind=test_function",
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:opens recovery when a previously stored session can no longer provide a token",
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:opens recovery when a previously stored session can no longer provide a token:kind=test_function"
+    ],
+    "files": {
+      "create": [],
+      "edit": [
+        "src/content/services/SupabaseAuthService.ts",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts"
+      ],
+      "read": [
+        "manifests/prevent-login-tabs-on-fresh-install.manifest.yaml",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts"
+      ]
+    },
+    "test_files": [
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts",
+      "src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+      "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts"
+    ],
+    "validate_commands": [
+      "pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+      "pnpm lint",
+      "pnpm check"
+    ]
+  }
+}

--- a/.maid/plan-locks/prevent-login-tabs-on-fresh-install.lock.json
+++ b/.maid/plan-locks/prevent-login-tabs-on-fresh-install.lock.json
@@ -1,0 +1,181 @@
+{
+  "manifest_path": "manifests/prevent-login-tabs-on-fresh-install.manifest.yaml",
+  "manifest_hash": "sha256:b438d70dfb8ab45197009111773d206bfccab804da14404f73ce1865010b1cf9",
+  "test_hashes": {
+    "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
+    "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+    "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+    "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:965fd6dea384cfb89bba056197eb5f1e9825441c8520f585f3aa81cb1862eeca"
+  },
+  "created_at": "2026-07-13T00:42:22.670522+00:00",
+  "revision": 5,
+  "revisions": [
+    {
+      "prior_manifest_hash": "sha256:85e097b5e84d3c211c67469acfc2e80a3e76ca11b99c324a1d475a316d7a4b30",
+      "prior_test_hashes": {
+        "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:863ff4c1e4dc2aeacfcb40df62ab20a3909b44f6ec9b45711cbbd34522137a31"
+      },
+      "revised_at": "2026-07-13T00:43:22.451541+00:00",
+      "reason": "Declare the approved SupabaseAuthService behavior change as writable edit scope after the strict scope hook rejected its initial read-only classification",
+      "agent": {
+        "model": "gpt-5",
+        "provider": "openai",
+        "client": "codex",
+        "skills": ["maid-implement-draft", "maid-evolver"],
+        "source": "flags"
+      },
+      "contract_delta": {
+        "artifacts_added": [
+          "src/content/services/SupabaseAuthService.ts:class:SupabaseAuthService",
+          "src/content/services/SupabaseAuthService.ts:class:SupabaseAuthService:kind=class"
+        ],
+        "artifacts_removed": [],
+        "files_added": ["edit:src/content/services/SupabaseAuthService.ts"],
+        "files_removed": ["read:src/content/services/SupabaseAuthService.ts"],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:c42f3a81b5dbbedd1fc6869df79968042123d269416e2800b5b885fa92fe98fc",
+      "prior_test_hashes": {
+        "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:863ff4c1e4dc2aeacfcb40df62ab20a3909b44f6ec9b45711cbbd34522137a31"
+      },
+      "revised_at": "2026-07-13T00:49:34.405147+00:00",
+      "reason": "Refresh the behavioral test hash after type-safe Chrome mock harness corrections that preserve the approved assertion and red evidence",
+      "agent": {
+        "model": "gpt-5",
+        "provider": "openai",
+        "client": "codex",
+        "skills": ["maid-implement-draft"],
+        "source": "flags"
+      },
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:c42f3a81b5dbbedd1fc6869df79968042123d269416e2800b5b885fa92fe98fc",
+      "prior_test_hashes": {
+        "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:bfcd572085cbee06560e313823c3b9b8d8bd52ad61d7f9fc0490ff22a5ade791"
+      },
+      "revised_at": "2026-07-13T00:54:28.410347+00:00",
+      "reason": "Capture the required post-review Outcome evidence without changing the approved contract",
+      "agent": {
+        "model": "gpt-5",
+        "provider": "openai",
+        "client": "codex",
+        "skills": ["maid-implement-draft", "maid-implementation-review"],
+        "source": "flags"
+      },
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:b438d70dfb8ab45197009111773d206bfccab804da14404f73ce1865010b1cf9",
+      "prior_test_hashes": {
+        "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:bfcd572085cbee06560e313823c3b9b8d8bd52ad61d7f9fc0490ff22a5ade791"
+      },
+      "revised_at": "2026-07-13T00:56:01.891976+00:00",
+      "reason": "Refresh the behavioral test hash after the pre-commit formatter applied a formatting-only line wrap",
+      "agent": {
+        "model": "gpt-5",
+        "provider": "openai",
+        "client": "codex",
+        "skills": ["maid-implement-draft"],
+        "source": "flags"
+      },
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    }
+  ],
+  "red_evidence": {
+    "red": true,
+    "captured_at": "2026-07-13T00:43:36.649784+00:00",
+    "commands": [
+      {
+        "command": "pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/background/__tests__/BackgroundService.welcome-flow.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+        "exit_code": 1,
+        "output_tail": "    Array [\n      Object {\n        \"active\": true,\n        \"url\": \"https://bolt2github.com/login\",\n      },\n    ]\n\n\nNumber of calls: 1\n\n \u276f src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:30:36\n     28|     await authService.forceCheck();\n     29| \n     30|     expect(chrome.tabs.create).not.toHaveBeenCalled();\n       |                                    ^\n     31|     expect(authService.getAuthState()).toMatchObject({\n     32|       isAuthenticated: false,\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n",
+        "classification": "red"
+      },
+      {
+        "command": "pnpm lint",
+        "exit_code": 0,
+        "output_tail": "\n> bolt-to-github@1.3.20 lint /home/atomrem/projects/codefrost-dev/bolt-to-github\n> eslint \"src/**/*.{js,ts,svelte}\"\n",
+        "classification": "not_red"
+      },
+      {
+        "command": "pnpm check",
+        "exit_code": 1,
+        "output_tail": "    vi.mocked(chrome.storage.local.set).mockResolvedValue(undefined);\n\n\n/home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:15:53\nError: Argument of type '{ id: number; }' is not assignable to parameter of type 'void'. \n    vi.mocked(chrome.tabs.query).mockResolvedValue([]);\n    vi.mocked(chrome.tabs.create).mockResolvedValue({ id: 123 });\n    vi.mocked(chrome.alarms.create).mockReturnValue(undefined);\n\n\n/home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:17:54\nError: Argument of type 'boolean' is not assignable to parameter of type 'void'. \n    vi.mocked(chrome.alarms.create).mockReturnValue(undefined);\n    vi.mocked(chrome.alarms.clear).mockResolvedValue(true);\n  });\n\n\n====================================\nsvelte-check found 3 errors and 0 warnings in 1 file\n\u2009ELIFECYCLE\u2009 Command failed with exit code 1.",
+        "classification": "red"
+      }
+    ]
+  },
+  "agent": {
+    "model": "gpt-5",
+    "provider": "openai",
+    "client": "codex",
+    "skills": ["maid-planner", "maid-evolver", "maid-implement-draft"],
+    "source": "flags"
+  },
+  "_manifest_contract": {
+    "artifacts": [
+      "src/content/services/SupabaseAuthService.ts:class:SupabaseAuthService",
+      "src/content/services/SupabaseAuthService.ts:class:SupabaseAuthService:kind=class",
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:does not open login tabs when an unauthenticated extension has no stored session",
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:does not open login tabs when an unauthenticated extension has no stored session:kind=test_function"
+    ],
+    "files": {
+      "create": ["src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts"],
+      "edit": ["src/content/services/SupabaseAuthService.ts"],
+      "read": [
+        "src/background/BackgroundService.ts",
+        "src/background/__tests__/BackgroundService.welcome-flow.test.ts",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts"
+      ]
+    },
+    "test_files": [
+      "src/background/__tests__/BackgroundService.welcome-flow.test.ts",
+      "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts",
+      "src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+      "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts"
+    ],
+    "validate_commands": [
+      "pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/background/__tests__/BackgroundService.welcome-flow.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts src/content/services/__tests__/SupabaseAuthService.reload.test.ts",
+      "pnpm lint",
+      "pnpm check"
+    ]
+  }
+}

--- a/.maid/plan-locks/prevent-login-tabs-on-fresh-install.lock.json
+++ b/.maid/plan-locks/prevent-login-tabs-on-fresh-install.lock.json
@@ -5,10 +5,10 @@
     "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
     "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
     "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
-    "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:965fd6dea384cfb89bba056197eb5f1e9825441c8520f585f3aa81cb1862eeca"
+    "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:c718ea793b4a0d1e3421354cc88f03cd52343a46cfdaad77702a39728cc35a83"
   },
   "created_at": "2026-07-13T00:42:22.670522+00:00",
-  "revision": 5,
+  "revision": 7,
   "revisions": [
     {
       "prior_manifest_hash": "sha256:85e097b5e84d3c211c67469acfc2e80a3e76ca11b99c324a1d475a316d7a4b30",
@@ -108,6 +108,46 @@
         "skills": ["maid-implement-draft"],
         "source": "flags"
       },
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:b438d70dfb8ab45197009111773d206bfccab804da14404f73ce1865010b1cf9",
+      "prior_test_hashes": {
+        "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:965fd6dea384cfb89bba056197eb5f1e9825441c8520f585f3aa81cb1862eeca"
+      },
+      "revised_at": "2026-07-13T02:14:18.542437+00:00",
+      "reason": "Refresh shared auth test hash after approved recovery coverage",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:b438d70dfb8ab45197009111773d206bfccab804da14404f73ce1865010b1cf9",
+      "prior_test_hashes": {
+        "src/background/__tests__/BackgroundService.welcome-flow.test.ts": "sha256:7816b709b1ae739093ca094a23bc5ddf21903e21732b980660a14f94668994e0",
+        "src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts": "sha256:8433144040598979ebb7c80b6b108842a0d93657d9f67eeb4b32fb29f7b3fb20",
+        "src/content/services/__tests__/SupabaseAuthService.reload.test.ts": "sha256:9d3add94bdb54e32cd9852396532020eb32b969df384c4e041c3955cabf95b02",
+        "src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts": "sha256:c718ea793b4a0d1e3421354cc88f03cd52343a46cfdaad77702a39728cc35a83"
+      },
+      "revised_at": "2026-07-13T02:19:34.697798+00:00",
+      "reason": "Refresh shared auth test hash after pre-commit formatting",
+      "agent": null,
       "contract_delta": {
         "artifacts_added": [],
         "artifacts_removed": [],

--- a/.maid/plan-locks/release-notes-v1-3-20.lock.json
+++ b/.maid/plan-locks/release-notes-v1-3-20.lock.json
@@ -2,10 +2,10 @@
   "manifest_path": "manifests/release-notes-v1-3-20.manifest.yaml",
   "manifest_hash": "sha256:1c5bd792ab5809bb8a868a451aa47fe4dc46387a2280c1a6ba0f878218f7e4fc",
   "test_hashes": {
-    "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:b9f3c98e21b1f5f92d76b3869cc220f63b878b7827d5ac8e9d955665921a2c62"
+    "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:959f63368810d58937bc2f06484fb1d27b57eb244a7fab9d4b9b3b597320b8c3"
   },
   "created_at": "2026-07-12T03:49:28.448519+00:00",
-  "revision": 3,
+  "revision": 5,
   "revisions": [
     {
       "prior_manifest_hash": "sha256:7fd8ccee8f06b6b8af9931535d426ba44a765452d4593a2976dd76318c0f3c43",
@@ -31,6 +31,40 @@
       },
       "revised_at": "2026-07-12T04:02:45.985537+00:00",
       "reason": "Capture reviewed completed Outcome and validation evidence",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:1c5bd792ab5809bb8a868a451aa47fe4dc46387a2280c1a6ba0f878218f7e4fc",
+      "prior_test_hashes": {
+        "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:b9f3c98e21b1f5f92d76b3869cc220f63b878b7827d5ac8e9d955665921a2c62"
+      },
+      "revised_at": "2026-07-13T02:14:18.226351+00:00",
+      "reason": "Refresh shared release-content test hash for cumulative v1.3.21 coverage",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:1c5bd792ab5809bb8a868a451aa47fe4dc46387a2280c1a6ba0f878218f7e4fc",
+      "prior_test_hashes": {
+        "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:b4120488c9ea5123912faa4a0417a4fe82ef9e55fad3dff9b5ea5f56fe753a3e"
+      },
+      "revised_at": "2026-07-13T02:19:33.122160+00:00",
+      "reason": "Refresh shared release test hash after pre-commit formatting",
       "agent": null,
       "contract_delta": {
         "artifacts_added": [],

--- a/.maid/plan-locks/release-v1-3-21.lock.json
+++ b/.maid/plan-locks/release-v1-3-21.lock.json
@@ -1,0 +1,137 @@
+{
+  "manifest_path": "manifests/release-v1-3-21.manifest.yaml",
+  "manifest_hash": "sha256:d030dd5e56db2cb14fe1aaa711ac3447de6a83f793be941a4350b705f44c8192",
+  "test_hashes": {
+    "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:959f63368810d58937bc2f06484fb1d27b57eb244a7fab9d4b9b3b597320b8c3"
+  },
+  "created_at": "2026-07-13T01:06:31.006371+00:00",
+  "revision": 4,
+  "revisions": [
+    {
+      "prior_manifest_hash": "sha256:09b4193617d10e6d63fa0667f1bb3d0d705c4f2af629a8baab5bbfdf87ea6b2b",
+      "prior_test_hashes": {
+        "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:7644b57fa20ba4516b292580bcc98c9bcaa8cc3a3dcb215136059cb0f026e04c"
+      },
+      "revised_at": "2026-07-13T01:51:11.795923+00:00",
+      "reason": "Include the repository development guide in the v1.3.21 version-alignment contract",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [
+          "CLAUDE.md:namespace:DevelopmentGuideVersion_1_3_21",
+          "CLAUDE.md:namespace:DevelopmentGuideVersion_1_3_21:kind=namespace"
+        ],
+        "artifacts_removed": [],
+        "files_added": ["edit:CLAUDE.md"],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:be07d060d8e9b416c25ec8008115644399db856a4f2c824f475b781fd518fa2f",
+      "prior_test_hashes": {
+        "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:b4120488c9ea5123912faa4a0417a4fe82ef9e55fad3dff9b5ea5f56fe753a3e"
+      },
+      "revised_at": "2026-07-13T02:09:53.865163+00:00",
+      "reason": "Capture reviewed completed Outcome evidence",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:d030dd5e56db2cb14fe1aaa711ac3447de6a83f793be941a4350b705f44c8192",
+      "prior_test_hashes": {
+        "src/lib/constants/__tests__/whatsNewContent.test.ts": "sha256:b4120488c9ea5123912faa4a0417a4fe82ef9e55fad3dff9b5ea5f56fe753a3e"
+      },
+      "revised_at": "2026-07-13T02:19:32.796028+00:00",
+      "reason": "Refresh behavioral test hash after pre-commit formatting",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    }
+  ],
+  "red_evidence": {
+    "red": true,
+    "captured_at": "2026-07-13T01:51:36.335794+00:00",
+    "commands": [
+      {
+        "command": "pnpm exec vitest run src/lib/constants/__tests__/whatsNewContent.test.ts",
+        "exit_code": 1,
+        "output_tail": "+\n+ ## Performance Considerations\n+\n+ - Minimize bundle sizes with proper code splitting\n+ - Optimize asset loading for extension context\n+ - Use proper Chrome extension performance patterns\n+ - Leverage Vite's optimization features\n+ - Test in both light and dark modes\n+\n\n \u276f src/lib/constants/__tests__/whatsNewContent.test.ts:22:44\n     20|     expect(PackageVersion_1_3_21.version).toBe('1.3.21');\n     21|     expect(ChromeManifestVersion_1_3_21.version).toBe('1.3.21');\n     22|     expect(DevelopmentGuideVersion_1_3_21).toContain('**Current Versio\u2026\n       |                                            ^\n     23|   });\n     24| \n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n",
+        "classification": "red"
+      },
+      {
+        "command": "pnpm lint",
+        "exit_code": 0,
+        "output_tail": "\n> bolt-to-github@1.3.21 lint /home/atomrem/projects/codefrost-dev/bolt-to-github\n> eslint \"src/**/*.{js,ts,svelte}\"\n",
+        "classification": "not_red"
+      },
+      {
+        "command": "pnpm check",
+        "exit_code": 1,
+        "output_tail": "> svelte-check --tsconfig ./tsconfig.json\n\n\n====================================\nLoading svelte-check in workspace: /home/atomrem/projects/codefrost-dev/bolt-to-github\nGetting Svelte diagnostics...\n\n/home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts:39:59\nError: Argument of type '{ supabaseToken: string; supabaseTokenExpiry: number; }' is not assignable to parameter of type 'void'. \n  test('opens recovery when a previously stored session can no longer provide a token', async () => {\n    vi.mocked(chrome.storage.local.get).mockResolvedValue({\n      supabaseToken: 'expired-access-token',\n      supabaseTokenExpiry: Date.now() - 60_000,\n    });\n\n\n\n====================================\nsvelte-check found 1 error and 0 warnings in 1 file\n\u2009ELIFECYCLE\u2009 Command failed with exit code 1.",
+        "classification": "red"
+      },
+      {
+        "command": "pnpm build",
+        "exit_code": 0,
+        "output_tail": "dist/pages/logs.js                                           15.32 kB \u2502 gzip:   5.72 kB\ndist/assets/debounce-CycWI4oj.js                             22.12 kB \u2502 gzip:   6.78 kB\ndist/assets/input-hfojewKS.js                                72.30 kB \u2502 gzip:  25.10 kB\ndist/assets/GitHubComparisonService-C-CwFltt.js              90.43 kB \u2502 gzip:  25.31 kB\ndist/background/background.js                               110.79 kB \u2502 gzip:  29.56 kB\ndist/content/content.js                                     245.60 kB \u2502 gzip:  72.19 kB\ndist/assets/index.html-BPVdM5_V.js                          511.55 kB \u2502 gzip: 131.80 kB\n\u2713 built in 9.31s\n\n[plugin:vite:reporter] [plugin vite:reporter] \n(!) /home/atomrem/projects/codefrost-dev/bolt-to-github/src/lib/constants/supabase.ts is dynamically imported by /home/atomrem/projects/codefrost-dev/bolt-to-github/src/services/UnifiedGitHubService.ts but also statically imported by /home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/services/SupabaseAuthService.ts, /home/atomrem/projects/codefrost-dev/bolt-to-github/src/services/BoltProjectSyncService.ts, /home/atomrem/projects/codefrost-dev/bolt-to-github/src/services/GitHubAppService.ts, /home/atomrem/projects/codefrost-dev/bolt-to-github/src/services/SubscriptionService.ts, dynamic import will not move module into another chunk.\n\n[plugin:vite:reporter] [plugin vite:reporter] \n(!) /home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/handlers/FileChangeHandler.ts is dynamically imported by /home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/handlers/GitHubUploadHandler.ts, /home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/services/PushReminderService.ts, /home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/services/PushReminderService.ts but also statically imported by /home/atomrem/projects/codefrost-dev/bolt-to-github/src/content/UIManager.ts, dynamic import will not move module into another chunk.\n\n\n(!) Some chunks are larger than 500 kB after minification. Consider:\n- Using dynamic import() to code-split the application\n- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks\n- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.",
+        "classification": "not_red"
+      }
+    ]
+  },
+  "agent": null,
+  "_manifest_contract": {
+    "artifacts": [
+      "CHANGELOG.md:namespace:Version_1_3_21_Changelog",
+      "CHANGELOG.md:namespace:Version_1_3_21_Changelog:kind=namespace",
+      "CLAUDE.md:namespace:DevelopmentGuideVersion_1_3_21",
+      "CLAUDE.md:namespace:DevelopmentGuideVersion_1_3_21:kind=namespace",
+      "README.md:namespace:Version_1_3_21_Readme",
+      "README.md:namespace:Version_1_3_21_Readme:kind=namespace",
+      "manifest.json:namespace:ChromeManifestVersion_1_3_21",
+      "manifest.json:namespace:ChromeManifestVersion_1_3_21:kind=namespace",
+      "package.json:namespace:PackageVersion_1_3_21",
+      "package.json:namespace:PackageVersion_1_3_21:kind=namespace",
+      "src/lib/constants/__tests__/whatsNewContent.test.ts:keeps package and Chrome manifest versions aligned for 1.3.21",
+      "src/lib/constants/__tests__/whatsNewContent.test.ts:keeps package and Chrome manifest versions aligned for 1.3.21:kind=test_function",
+      "src/lib/constants/__tests__/whatsNewContent.test.ts:keeps the v1.3.21 release surfaces final and user-facing",
+      "src/lib/constants/__tests__/whatsNewContent.test.ts:keeps the v1.3.21 release surfaces final and user-facing:kind=test_function"
+    ],
+    "files": {
+      "create": [],
+      "edit": [
+        "CHANGELOG.md",
+        "CLAUDE.md",
+        "README.md",
+        "manifest.json",
+        "package.json",
+        "src/lib/constants/__tests__/whatsNewContent.test.ts"
+      ],
+      "read": [
+        "manifests/prevent-login-tabs-on-fresh-install.manifest.yaml",
+        "manifests/release-notes-v1-3-20.manifest.yaml",
+        "src/content/services/SupabaseAuthService.ts"
+      ]
+    },
+    "test_files": ["src/lib/constants/__tests__/whatsNewContent.test.ts"],
+    "validate_commands": [
+      "pnpm exec vitest run src/lib/constants/__tests__/whatsNewContent.test.ts",
+      "pnpm lint",
+      "pnpm check",
+      "pnpm build"
+    ]
+  }
+}

--- a/.maid/plan-locks/repair-e2e-lifecycle-storage-contracts.lock.json
+++ b/.maid/plan-locks/repair-e2e-lifecycle-storage-contracts.lock.json
@@ -2,10 +2,10 @@
   "manifest_path": "manifests/repair-e2e-lifecycle-storage-contracts.manifest.yaml",
   "manifest_hash": "sha256:0363b59eef22f8cb4a0a3a53324b7bcc67db0ab884f8cf38a4c6d2914feee5c9",
   "test_hashes": {
-    "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:cc81bcd9951b62ad2e864c110c588176d6941b2ba5f0864ce9a34dab201b9cf8"
+    "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:407c18bebfea921a7877825349ed2ca751ea1b662576b1074ac2f6b6b732f409"
   },
   "created_at": "2026-07-12T03:35:05.162053+00:00",
-  "revision": 6,
+  "revision": 8,
   "revisions": [
     {
       "prior_manifest_hash": "sha256:7970bfa995372c75274cf82cf4e1595eef661d8f07e1c842b38d91af6d7b2047",
@@ -119,6 +119,40 @@
       },
       "revised_at": "2026-07-12T04:02:45.375767+00:00",
       "reason": "Capture reviewed completed Outcome and validation evidence",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:0363b59eef22f8cb4a0a3a53324b7bcc67db0ab884f8cf38a4c6d2914feee5c9",
+      "prior_test_hashes": {
+        "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:cc81bcd9951b62ad2e864c110c588176d6941b2ba5f0864ce9a34dab201b9cf8"
+      },
+      "revised_at": "2026-07-13T02:14:17.589739+00:00",
+      "reason": "Refresh shared behavioral test hash after approved additive E2E coverage",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:0363b59eef22f8cb4a0a3a53324b7bcc67db0ab884f8cf38a4c6d2914feee5c9",
+      "prior_test_hashes": {
+        "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:4497a0d8b09ecd32db0a7e64949c7db02b4e00bca7fe254f9f7d27f96abaf451"
+      },
+      "revised_at": "2026-07-13T02:19:33.756371+00:00",
+      "reason": "Refresh shared E2E test hash after pre-commit formatting",
       "agent": null,
       "contract_delta": {
         "artifacts_added": [],

--- a/.maid/plan-locks/retire-stale-e2e-errors-suite.lock.json
+++ b/.maid/plan-locks/retire-stale-e2e-errors-suite.lock.json
@@ -2,10 +2,10 @@
   "manifest_path": "manifests/retire-stale-e2e-errors-suite.manifest.yaml",
   "manifest_hash": "sha256:5408a1279b1456adccf955d57f9b08fc5affd1c02c531f9ab8960db873863ea5",
   "test_hashes": {
-    "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:cc81bcd9951b62ad2e864c110c588176d6941b2ba5f0864ce9a34dab201b9cf8"
+    "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:407c18bebfea921a7877825349ed2ca751ea1b662576b1074ac2f6b6b732f409"
   },
   "created_at": "2026-07-12T03:43:10.573861+00:00",
-  "revision": 5,
+  "revision": 7,
   "revisions": [
     {
       "prior_manifest_hash": "sha256:6077e14478cb8e75e9a30b3a2d938ce4459315a8417f0613578dde8a7385c137",
@@ -77,6 +77,40 @@
       },
       "revised_at": "2026-07-12T04:02:45.678227+00:00",
       "reason": "Capture reviewed completed Outcome and validation evidence",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:5408a1279b1456adccf955d57f9b08fc5affd1c02c531f9ab8960db873863ea5",
+      "prior_test_hashes": {
+        "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:cc81bcd9951b62ad2e864c110c588176d6941b2ba5f0864ce9a34dab201b9cf8"
+      },
+      "revised_at": "2026-07-13T02:14:17.912821+00:00",
+      "reason": "Refresh shared behavioral test hash after approved additive E2E coverage",
+      "agent": null,
+      "contract_delta": {
+        "artifacts_added": [],
+        "artifacts_removed": [],
+        "files_added": [],
+        "files_removed": [],
+        "validate_commands_added": [],
+        "validate_commands_removed": []
+      }
+    },
+    {
+      "prior_manifest_hash": "sha256:5408a1279b1456adccf955d57f9b08fc5affd1c02c531f9ab8960db873863ea5",
+      "prior_test_hashes": {
+        "src/test/e2e-helpers/popup-helpers.test.ts": "sha256:4497a0d8b09ecd32db0a7e64949c7db02b4e00bca7fe254f9f7d27f96abaf451"
+      },
+      "revised_at": "2026-07-13T02:19:34.068741+00:00",
+      "reason": "Refresh shared E2E test hash after pre-commit formatting",
       "agent": null,
       "contract_delta": {
         "artifacts_added": [],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-07-13 - Version 1.3.21
+
+### 🐛 Bug Fixes
+
+- **Fresh-Install Login Tab Fix** - Brand-new unauthenticated installs now open only the intended welcome page instead of treating an absent session as an expired session and opening one or more automatic login tabs
+- **Recovery Behavior Preserved** - Existing tokens that fail verification still follow the established guided re-authentication path; only the expected no-session onboarding state is passive
+
+### 🧪 Testing & Quality
+
+- **First-Install Regression Coverage** - Public-path auth tests verify that overlapping startup checks keep the extension unauthenticated without creating login tabs, while welcome-page and invalid-session recovery coverage remains green
+- **Release Version Contract** - Package metadata, Chrome manifest metadata, changelog, README, and cumulative in-app release notes are checked together for v1.3.21
+
 ## 2026-07-12 - Version 1.3.20
 
 ### ✨ New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Bolt to GitHub is a Chrome Extension (Manifest v3) that automatically captures ZIP file downloads from bolt.new, extracts them, and pushes contents to GitHub repositories. Built with Svelte v4.2.x, TypeScript v5.9.x, and TailwindCSS.
 
-**Current Version**: v1.3.20
+**Current Version**: v1.3.21
 **Repository**: mamertofabian/bolt-to-github  
 **Package Manager**: pnpm (required)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,23 @@ A Chrome extension that automatically captures ZIP file downloads from bolt.new,
   <img src="https://img.shields.io/badge/Install%20from-Chrome%20Web%20Store-blue?style=for-the-badge&logo=google-chrome&logoColor=white" alt="Install from Chrome Web Store" height="40">
 </a>
 
-### Latest Version: v1.3.20
+### Latest Version: v1.3.21
+
+#### Version 1.3.21 - Cleaner First-Install Onboarding (July 2026)
+
+**What's new:**
+
+- New extension installs open only the welcome page instead of also opening automatic login tabs
+- Empty sessions are treated as the expected onboarding state rather than an expired login
+- Existing invalid or expired sessions still keep their guided recovery behavior
+
+**Key Benefits:**
+
+- Cleaner first-run experience with no duplicate, focus-stealing login tabs
+- Sign-in starts from the welcome flow or another explicit user action
+- Established authentication recovery remains available when a real session fails
+
+### Previous Version: v1.3.20
 
 #### Version 1.3.20 - Auth Containment & Post-Push Guidance (July 2026)
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -92,13 +92,11 @@ test.describe('Authentication Flow', () => {
       // Wait a moment for validation
       await page.waitForTimeout(500);
 
-      // Should disable the Complete Setup button
-      const saveButton = page.locator('button:has-text("Complete Setup")').first();
-      await saveButton.waitFor({ state: 'visible', timeout: 5000 });
-      const isDisabled = await saveButton.isDisabled();
-
-      // Button should be disabled with empty token
-      expect(isDisabled).toBe(true);
+      // The current onboarding surface labels this action "Get Started";
+      // retain the legacy label as a compatibility fallback.
+      const saveButton = page.getByRole('button', { name: /get started|complete setup/i });
+      await expect(saveButton).toBeVisible();
+      await expect(saveButton).toBeDisabled();
 
       await page.close();
     });
@@ -112,13 +110,9 @@ test.describe('Authentication Flow', () => {
       // Wait a moment for validation
       await page.waitForTimeout(500);
 
-      // Should disable the Complete Setup button
-      const saveButton = page.locator('button:has-text("Complete Setup")').first();
-      await saveButton.waitFor({ state: 'visible', timeout: 5000 });
-      const isDisabled = await saveButton.isDisabled();
-
-      // Button should be disabled with empty username
-      expect(isDisabled).toBe(true);
+      const saveButton = page.getByRole('button', { name: /get started|complete setup/i });
+      await expect(saveButton).toBeVisible();
+      await expect(saveButton).toBeDisabled();
 
       await page.close();
     });

--- a/e2e/error-flow-product.spec.ts
+++ b/e2e/error-flow-product.spec.ts
@@ -19,9 +19,8 @@ async function seedProductAuth(
 ) {
   await setGitHubSettings(context, extensionId, {
     repoOwner: 'testuser',
-    authenticationMethod: 'github_app',
-    githubAppInstallationId: 12345,
-    githubAppUsername: 'testuser',
+    githubToken: 'ghp_e2e_product_token',
+    authenticationMethod: 'pat',
     projectSettings: {
       [ERROR_FLOW_PROJECT_ID]: {
         repoName,
@@ -62,6 +61,14 @@ async function openPopupForBoltProject(
   repoName = 'test-repo'
 ) {
   await seedProductAuth(context, extensionId, repoName);
+
+  await context.route('https://api.github.com/users/testuser', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ login: 'testuser' }),
+    });
+  });
 
   await context.route('https://bolt.new/**', async (route) => {
     await route.fulfill({

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bolt to GitHub",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "Automatically process your Bolt project zip files and upload them to your GitHub repository.",
   "icons": {
     "16": "assets/icons/icon16.png",

--- a/manifests/align-e2e-auth-with-live-connection-gate.manifest.yaml
+++ b/manifests/align-e2e-auth-with-live-connection-gate.manifest.yaml
@@ -1,0 +1,76 @@
+schema: '2'
+goal: Align browser auth fixtures with the live GitHub connection gate
+type: fix
+created: '2026-07-13T01:12:43Z'
+description: |
+  Repair stale browser coverage exposed by the v1.3.20 live-connection gate.
+  PAT onboarding validation should recognize the current Get Started control,
+  and product-visible repository/push error scenarios should seed the supported
+  PAT path instead of fabricating a GitHub App installation without a Supabase
+  session. Production correctly blocks that fabricated state, so this change is
+  limited to browser specs and a fast source-contract regression.
+temptations:
+- risk: Do not weaken the live GitHub connection gate so storage-only GitHub App fixtures can mount protected surfaces.
+  instead: Use PAT setup for error scenarios that are not GitHub-App-specific.
+- risk: Do not add sleeps or extend timeouts around controls that are not rendered.
+  instead: Seed a supported authentication path and locate the current accessible control name.
+- risk: Do not place Playwright commands back into the fast MAID behavioral gate.
+  instead: Pin browser-spec setup through the existing fast source-contract test and keep Playwright as release evidence.
+files:
+  edit:
+  - path: src/test/e2e-helpers/popup-helpers.test.ts
+    artifacts:
+    - kind: test_function
+      name: pins PAT onboarding validation to the current submit control
+    - kind: test_function
+      name: seeds product error flows through a live PAT connection
+  scope:
+  - path: e2e/auth.spec.ts
+    reason: Update stale onboarding button locators without changing production behavior.
+  - path: e2e/error-flow-product.spec.ts
+    reason: Replace fabricated GitHub App state with a valid PAT fixture for non-auth-specific product error scenarios.
+  read:
+  - e2e/helpers/popup.ts
+  - e2e/helpers/storage.ts
+  - src/lib/utils/githubConnection.ts
+  - manifests/gate-github-actions-on-live-connection.manifest.yaml
+validate:
+- pnpm exec vitest run src/test/e2e-helpers/popup-helpers.test.ts
+- pnpm lint
+- pnpm check
+metadata:
+  tags:
+  - e2e
+  - auth
+  - release-ci
+  priority: high
+  promotion_ready: true
+outcome:
+  status: completed
+  summary: |
+    Updated stale browser fixtures to use the current accessible onboarding
+    control and a live-valid PAT setup for product error scenarios. Production
+    GitHub connection gating remains unchanged.
+  rationale: |
+    The v1.3.20 live-connection gate correctly rejected a fabricated GitHub App
+    installation without a Supabase session; browser coverage needed to seed a
+    supported connection rather than weaken production behavior.
+  lessons:
+  - lesson_type: browser-fixture-fidelity
+    summary: Protected-surface E2E fixtures must satisfy the same live-connection contract as production state.
+    tags: [e2e, auth, fixtures]
+    paths: [e2e/error-flow-product.spec.ts]
+  review_notes:
+  - source: independent reviewer /root/repeat_release_review
+    severity: ready
+    summary: Review confirmed the PAT fixture and GitHub username route do not weaken production connection gating.
+  validation:
+  - command: [pnpm, exec, vitest, run, src/test/e2e-helpers/popup-helpers.test.ts]
+    status: passed
+    summary: Nine fast source-contract tests passed after red evidence for both stale fixture paths.
+  - command: [./scripts/maid, validate, manifests/align-e2e-auth-with-live-connection-gate.manifest.yaml, --mode, implementation, --run-tests]
+    status: passed
+    summary: Focused contract tests, lint, and type checking passed.
+  - command: [pnpm, test:e2e]
+    status: passed
+    summary: Full Playwright suite passed 59 scenarios with three intentional skips.

--- a/manifests/preserve-stored-session-recovery.manifest.yaml
+++ b/manifests/preserve-stored-session-recovery.manifest.yaml
@@ -1,0 +1,84 @@
+schema: '2'
+goal: Preserve guided recovery when a previously stored Supabase session can no longer provide a token
+type: fix
+created: '2026-07-13T01:52:32Z'
+description: |
+  Distinguish a truly empty first-install session from a stored session whose
+  access or refresh credentials are expired or invalid. Empty storage remains
+  passive so installation opens only the welcome page, while a failed stored
+  session continues through the established re-authentication UI and login-tab
+  recovery path, even when token resolution clears stale refresh credentials.
+temptations:
+- risk: Do not restore automatic login tabs for empty first-install storage.
+  instead: Snapshot whether stored Supabase credentials existed before token resolution can clear or discard them.
+- risk: Do not test private auth helpers directly.
+  instead: Drive both empty and failed stored-session behavior through getInstance and forceCheck, then assert observable tab navigation and auth state.
+- risk: Do not weaken token expiry or refresh validation to keep a token available.
+  instead: Preserve the failed-session classification separately from successful token resolution.
+files:
+  edit:
+  - path: src/content/services/SupabaseAuthService.ts
+    artifacts:
+    - kind: class
+      name: SupabaseAuthService
+      description: Empty sessions remain passive, while previously stored sessions that fail token resolution launch guided re-authentication.
+  - path: src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts
+    artifacts:
+    - kind: test_function
+      name: opens recovery when a previously stored session can no longer provide a token
+    - kind: test_function
+      name: opens only one recovery tab when stored-session checks overlap
+  read:
+  - manifests/prevent-login-tabs-on-fresh-install.manifest.yaml
+  - src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts
+  - src/content/services/__tests__/SupabaseAuthService.reload.test.ts
+validate:
+- pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts src/content/services/__tests__/SupabaseAuthService.reload.test.ts
+- pnpm lint
+- pnpm check
+metadata:
+  tags:
+  - auth
+  - recovery
+  - onboarding
+  priority: high
+  promotion_ready: true
+outcome:
+  status: completed
+  summary: |
+    Authentication checks now distinguish empty first-install storage from a
+    previously stored session that fails token resolution. Guided recovery is
+    preserved for the latter and overlapping checks share one stored-session
+    recovery side effect.
+  rationale: |
+    Token resolution can clear stale credentials before returning null, so the
+    prior fresh-install correction accidentally made some expired sessions
+    passive. Snapshotting credential presence preserves classification, while a
+    narrow single-flight guard prevents duplicate tabs without changing the
+    established rapid-failure reload threshold.
+  lessons:
+  - lesson_type: auth-state-classification
+    summary: Preserve pre-resolution credential presence when cleanup can erase the evidence needed to distinguish failed and absent sessions.
+    tags: [auth, recovery, storage]
+    paths: [src/content/services/SupabaseAuthService.ts]
+  - lesson_type: scoped-concurrency-control
+    summary: Deduplicate only stored-session recovery so overlapping MV3 checks cannot duplicate tabs while other failure thresholds retain their behavior.
+    tags: [auth, concurrency, mv3]
+    paths: [src/content/services/SupabaseAuthService.ts]
+  review_notes:
+  - source: independent reviewer /root/repeat_release_review
+    severity: ready
+    summary: Final re-review confirmed the classification fix, public-path concurrency coverage, narrow guard, cleanup reset, and preserved reload semantics.
+  validation:
+  - command: [pnpm, exec, vitest, run, src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts]
+    status: failed-red-phase
+    summary: Sequential recovery initially opened no tab; the later overlapping scenario reproduced two login tabs before concurrency protection.
+  - command: [./scripts/maid, validate, manifests/preserve-stored-session-recovery.manifest.yaml, --mode, implementation, --run-tests]
+    status: passed
+    summary: Focused auth, cleanup, reload-threshold, lint, and type-check gates passed.
+  - command: [pnpm, test:ci]
+    status: passed
+    summary: Full Vitest suite passed 195 files and 4,364 tests.
+  - command: [pnpm, test:e2e]
+    status: passed
+    summary: Full Playwright suite passed 59 scenarios with three intentional skips.

--- a/manifests/prevent-login-tabs-on-fresh-install.manifest.yaml
+++ b/manifests/prevent-login-tabs-on-fresh-install.manifest.yaml
@@ -1,0 +1,165 @@
+schema: '2'
+goal: Fresh extension installs open only the welcome page, without automatic login tabs
+type: fix
+description: |
+  Root cause: SupabaseAuthService.checkAuthStatus() treats an absent session as
+  an expired-session failure and calls triggerReAuthentication(). On a fresh
+  service-worker startup, the service's initial check, its short onboarding
+  interval, and BackgroundService's forced startup check can overlap before
+  post-connection mode is established. Each recovery attempt is allowed to
+  create https://bolt2github.com/login, so installation can open two login tabs
+  in addition to the intended welcome page.
+
+  Fix contract: an unauthenticated check with no stored or discoverable token
+  records the unauthenticated state but does not launch re-authentication UI or
+  create a login tab. The installation listener remains the sole automatic tab
+  opener for a fresh install and continues to open the welcome page. A token
+  that exists but fails verification remains a genuine recovery failure and
+  keeps the established re-authentication behavior.
+
+  Rationale: absence of credentials is the expected first-install state, not a
+  broken session. Login navigation should come from the welcome/onboarding UI or
+  an explicit user action; automatic recovery is reserved for sessions that
+  previously existed and became invalid.
+temptations:
+- risk: Do not deduplicate login tabs after creating them; that still races, steals focus, and treats first-install onboarding as a recovery failure.
+  instead: Stop the no-token branch before triggerReAuthentication while preserving the invalid-token recovery branch.
+- risk: Do not suppress every re-authentication request just to make the install test pass.
+  instead: Keep token-verification failures and explicit OPEN_REAUTHENTICATION requests on their existing recovery paths.
+- risk: Do not test private checkAuthStatus or triggerReAuthentication helpers directly.
+  instead: Drive the empty-session scenario through public getInstance and forceCheck, then assert the observable tab behavior.
+files:
+  edit:
+  - path: src/content/services/SupabaseAuthService.ts
+    artifacts:
+    - kind: class
+      name: SupabaseAuthService
+      description: |
+        Empty-session authentication checks keep the service unauthenticated
+        without launching re-authentication UI or opening a login tab. Existing
+        tokens that fail verification continue through re-authentication.
+  create:
+  - path: src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts
+    artifacts:
+    - kind: test_function
+      name: does not open login tabs when an unauthenticated extension has no stored session
+  read:
+  - src/background/BackgroundService.ts
+  - src/background/__tests__/BackgroundService.welcome-flow.test.ts
+  - src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts
+  - src/content/services/__tests__/SupabaseAuthService.reload.test.ts
+validate:
+- pnpm exec vitest run src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts src/background/__tests__/BackgroundService.welcome-flow.test.ts src/content/services/__tests__/SupabaseAuthService.session-cleanup.test.ts src/content/services/__tests__/SupabaseAuthService.reload.test.ts
+- pnpm lint
+- pnpm check
+created: '2026-07-13T00:42:13Z'
+metadata:
+  tags:
+  - auth
+  - onboarding
+  - mv3
+  - tabs
+  priority: high
+  depends_on: []
+  promotion_ready: false
+  notes: |
+    Additive chain-merge evolution: no existing public artifact is renamed,
+    removed, or given a new signature. SupabaseAuthService.ts is an already
+    covered call site whose no-token branch is narrowed without changing its
+    public API.
+outcome:
+  status: completed
+  summary: |
+    Fresh unauthenticated extension startup no longer launches
+    bolt2github.com/login when no stored or discoverable session exists. The
+    install listener remains responsible for opening the welcome page, while
+    existing-token verification failures retain their re-authentication path.
+  rationale: |
+    Missing credentials are expected during first-install onboarding and must
+    not be treated as an expired-session recovery event. Keeping the no-token
+    branch passive prevents overlapping MV3 startup checks from opening
+    duplicate login tabs without weakening explicit or invalid-token recovery.
+  lessons:
+  - lesson_type: auth-state-classification
+    summary: |
+      Authentication startup must distinguish an absent session from a session
+      that existed and failed verification; only the latter warrants automatic
+      recovery UI.
+    tags:
+    - auth
+    - onboarding
+    - mv3
+    paths:
+    - src/content/services/SupabaseAuthService.ts
+  - lesson_type: startup-side-effect-control
+    summary: |
+      Short polling and forced startup checks may overlap in MV3 service
+      workers, so expected unauthenticated checks must remain idempotent and
+      free of navigation side effects.
+    tags:
+    - mv3
+    - concurrency
+    - tabs
+    paths:
+    - src/content/services/SupabaseAuthService.ts
+    - src/background/BackgroundService.ts
+  review_notes:
+  - source: independent reviewer /root/maid_implementation_reviewer
+    severity: ready
+    summary: |
+      Read-only implementation review found no blocking, should-fix, or scope
+      findings and returned Ready to merge after confirming auth recovery,
+      behavioral coverage, plan-lock integrity, and implementation scope.
+  validation:
+  - command:
+    - pnpm
+    - exec
+    - vitest
+    - run
+    - src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts
+    status: failed-red-phase
+    summary: |
+      Before implementation, the regression test failed because
+      chrome.tabs.create opened https://bolt2github.com/login for empty storage.
+  - command:
+    - ./scripts/maid
+    - test
+    - --manifest
+    - manifests/prevent-login-tabs-on-fresh-install.manifest.yaml
+    status: passed
+    summary: Focused 24-test auth/welcome suite, lint, and type checking passed.
+  - command:
+    - ./scripts/maid
+    - validate
+    - manifests/prevent-login-tabs-on-fresh-install.manifest.yaml
+    - --mode
+    - implementation
+    status: passed
+    summary: The promoted manifest passed implementation validation.
+  - command:
+    - pnpm
+    - test:ci
+    status: passed
+    summary: Full Vitest CI suite passed 195 files and 4,358 tests.
+  - command:
+    - pnpm
+    - build
+    status: passed
+    summary: Production extension build passed with existing Vite chunk warnings only.
+  - command:
+    - ./scripts/maid
+    - verify
+    - --manifest-dir
+    - manifests
+    - --require-plan-lock
+    - --require-red-evidence
+    - --plan-lock-scope
+    - task
+    - --file-tracking-scope
+    - task
+    - --since
+    - HEAD
+    - --keep-going
+    - --summary
+    status: passed
+    summary: All nine MAID verification gates passed with zero blocking findings or warnings.

--- a/manifests/release-v1-3-21.manifest.yaml
+++ b/manifests/release-v1-3-21.manifest.yaml
@@ -1,0 +1,110 @@
+schema: '2'
+goal: Prepare v1.3.21 for Chrome Web Store submission after the fresh-install onboarding fix
+type: fix
+created: '2026-07-13T01:06:30Z'
+description: |
+  Bump the extension and package versions together to 1.3.21 and add final
+  release copy for the fresh-install onboarding correction. The changelog may
+  record engineering and validation detail, while README and in-extension copy
+  must stay user-facing: a new install opens only the welcome page, empty
+  sessions do not open duplicate login tabs, and invalid existing sessions keep
+  their recovery behavior. Because v1.3.20 was published on GitHub but not
+  submitted to CWS, the v1.3.21 in-app entry is cumulative and also includes
+  v1.3.20 GitHub App loop containment, stable background checks, and the
+  post-push Pro follow-up. This additively evolves the release-note chain without
+  changing the WhatsNewVersion public interface.
+temptations:
+- risk: Do not move or replace the already-published v1.3.20 tag or ZIP.
+  instead: Publish the code fix under the new immutable v1.3.21 version.
+- risk: Do not bump only manifest.json or package.json.
+  instead: Keep both version fields aligned and enforce them with one release-contract test.
+- risk: Do not imply that automatic recovery was removed for expired or invalid existing sessions.
+  instead: Limit the release claim to empty-session first-install behavior and state that established recovery remains.
+- risk: Do not show only the incremental v1.3.21 fix in the in-app modal.
+  instead: Include the user-facing v1.3.20 highlights because CWS users will upgrade directly from v1.3.19 to v1.3.21.
+files:
+  edit:
+  - path: package.json
+    artifacts:
+    - kind: namespace
+      name: PackageVersion_1_3_21
+      description: Package metadata version is exactly 1.3.21.
+  - path: manifest.json
+    artifacts:
+    - kind: namespace
+      name: ChromeManifestVersion_1_3_21
+      description: Chrome extension manifest version is exactly 1.3.21.
+  - path: CHANGELOG.md
+    artifacts:
+    - kind: namespace
+      name: Version_1_3_21_Changelog
+      description: Developer-facing v1.3.21 release record for the fresh-install onboarding fix.
+  - path: README.md
+    artifacts:
+    - kind: namespace
+      name: Version_1_3_21_Readme
+      description: User-facing current release summary with v1.3.20 retained as the previous version.
+  - path: CLAUDE.md
+    artifacts:
+    - kind: namespace
+      name: DevelopmentGuideVersion_1_3_21
+      description: Repository development guidance identifies v1.3.21 as the current release.
+  - path: src/lib/constants/__tests__/whatsNewContent.test.ts
+    artifacts:
+    - kind: test_function
+      name: keeps package and Chrome manifest versions aligned for 1.3.21
+    - kind: test_function
+      name: keeps the v1.3.21 release surfaces final and user-facing
+  scope:
+  - path: src/lib/constants/whatsNewContent.ts
+    reason: Add the v1.3.21 content entry without changing the active WhatsNewVersion interface contract.
+  read:
+  - manifests/prevent-login-tabs-on-fresh-install.manifest.yaml
+  - manifests/release-notes-v1-3-20.manifest.yaml
+  - src/content/services/SupabaseAuthService.ts
+validate:
+- pnpm exec vitest run src/lib/constants/__tests__/whatsNewContent.test.ts
+- pnpm lint
+- pnpm check
+- pnpm build
+metadata:
+  tags:
+  - release
+  - chrome-web-store
+  - onboarding
+  - auth
+  priority: high
+  promotion_ready: true
+outcome:
+  status: completed
+  summary: |
+    Prepared every v1.3.21 release surface with aligned package, Chrome
+    manifest, and development-guide versions. The in-app entry is intentionally
+    cumulative, combining the fresh-install correction with the v1.3.20 changes
+    that were published on GitHub but not submitted to the Chrome Web Store.
+  rationale: |
+    Publishing the additional fix as v1.3.21 preserves the immutable v1.3.20
+    release while ensuring CWS users upgrading from v1.3.19 see the complete set
+    of changes they will actually receive.
+  lessons:
+  - lesson_type: cumulative-store-release-notes
+    summary: In-app notes should follow the store upgrade path when an intermediate GitHub release was not submitted to the store.
+    tags: [release, chrome-web-store, release-notes]
+    paths: [src/lib/constants/whatsNewContent.ts]
+  review_notes:
+  - source: independent reviewer /root/repeat_release_review
+    severity: ready
+    summary: Final read-only review found release/version surfaces accurate, cumulative, and correctly scoped.
+  validation:
+  - command: [pnpm, exec, vitest, run, src/lib/constants/__tests__/whatsNewContent.test.ts]
+    status: passed
+    summary: Six release-content and version-contract tests passed after red-first version assertions.
+  - command: [./scripts/maid, validate, manifests/release-v1-3-21.manifest.yaml, --mode, implementation, --run-tests]
+    status: passed
+    summary: Focused release tests, lint, type checking, and production build passed.
+  - command: [pnpm, test:ci]
+    status: passed
+    summary: Full Vitest suite passed 195 files and 4,364 tests.
+  - command: [pnpm, test:e2e]
+    status: passed
+    summary: Full Playwright suite passed 59 scenarios with three intentional skips.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bolt-to-github",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "type": "module",
   "engines": {
     "node": "^18.0.0 || ^20.0.0 || >=22.0.0"

--- a/src/content/services/SupabaseAuthService.ts
+++ b/src/content/services/SupabaseAuthService.ts
@@ -91,6 +91,7 @@ export class SupabaseAuthService {
   private consecutiveAuthFailures: number = 0;
   private lastReloadTimestamp: number = 0;
   private reloadRequested: boolean = false;
+  private storedSessionRecoveryInProgress: boolean = false;
   private readonly MAX_AUTH_FAILURES_BEFORE_RELOAD = 3;
   private readonly MIN_TIME_BETWEEN_RELOADS = 5 * 60 * 1000; /* 5 minutes */
 
@@ -550,6 +551,17 @@ export class SupabaseAuthService {
     try {
       logger.info('🔄 Checking authentication status...');
 
+      // Token resolution may clear an expired session before returning null.
+      // Preserve whether credentials existed so a failed stored session is not
+      // mistaken for a genuinely empty first-install state.
+      const storedSession = await chrome.storage.local.get([
+        'supabaseToken',
+        'supabaseRefreshToken',
+      ]);
+      const hadStoredSession = Boolean(
+        storedSession.supabaseToken || storedSession.supabaseRefreshToken
+      );
+
       /* Try to get authentication token from various sources */
       const token = await this.getAuthToken();
 
@@ -624,6 +636,18 @@ export class SupabaseAuthService {
         // automatic re-authentication for tokens that existed but failed
         // verification; sign-in for a new session starts from the welcome UI
         // or another explicit user action.
+        if (
+          hadStoredSession &&
+          !this.isPostConnectionMode &&
+          !this.storedSessionRecoveryInProgress
+        ) {
+          this.storedSessionRecoveryInProgress = true;
+          try {
+            await this.triggerReAuthentication('Stored session could not be recovered');
+          } finally {
+            this.storedSessionRecoveryInProgress = false;
+          }
+        }
       }
     } catch (error) {
       logger.error('Error checking auth status:', error);
@@ -1731,6 +1755,7 @@ export class SupabaseAuthService {
     /* Reset failure counter and reload flag (but preserve reload timestamp to prevent loops) */
     this.consecutiveAuthFailures = 0;
     this.reloadRequested = false;
+    this.storedSessionRecoveryInProgress = false;
 
     logger.info('🧹 Cleaned up SupabaseAuthService including aggressive detection');
   }

--- a/src/content/services/SupabaseAuthService.ts
+++ b/src/content/services/SupabaseAuthService.ts
@@ -620,10 +620,10 @@ export class SupabaseAuthService {
           subscription: { isActive: false, plan: 'free' },
         });
 
-        // No token at all – kick off onboarding / re-auth automatically
-        if (!this.isPostConnectionMode) {
-          await this.triggerReAuthentication('No authentication token found');
-        }
+        // An absent session is expected during first-install onboarding. Keep
+        // automatic re-authentication for tokens that existed but failed
+        // verification; sign-in for a new session starts from the welcome UI
+        // or another explicit user action.
       }
     } catch (error) {
       logger.error('Error checking auth status:', error);

--- a/src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts
+++ b/src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { SupabaseAuthService } from '../SupabaseAuthService';
+
+describe('SupabaseAuthService - fresh installation', () => {
+  let authService: SupabaseAuthService | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(chrome.storage.local.set).mockResolvedValue(undefined);
+    vi.mocked(chrome.storage.local.remove).mockResolvedValue(undefined);
+    vi.mocked(chrome.storage.sync.set).mockResolvedValue(undefined);
+    vi.mocked(chrome.tabs.query).mockResolvedValue([]);
+    vi.mocked(chrome.alarms.create).mockReturnValue(undefined);
+    chrome.alarms.clear = vi.fn(() =>
+      Promise.resolve(true)
+    ) as unknown as typeof chrome.alarms.clear;
+  });
+
+  afterEach(() => {
+    authService?.cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('does not open login tabs when an unauthenticated extension has no stored session', async () => {
+    authService = SupabaseAuthService.getInstance();
+
+    await authService.forceCheck();
+
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+    expect(authService.getAuthState()).toMatchObject({
+      isAuthenticated: false,
+      user: null,
+      subscription: { isActive: false, plan: 'free' },
+    });
+  });
+});

--- a/src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts
+++ b/src/content/services/__tests__/SupabaseAuthService.fresh-install.test.ts
@@ -34,4 +34,72 @@ describe('SupabaseAuthService - fresh installation', () => {
       subscription: { isActive: false, plan: 'free' },
     });
   });
+
+  test('opens recovery when a previously stored session can no longer provide a token', async () => {
+    const storedSession: Record<string, unknown> = {
+      supabaseToken: 'expired-access-token',
+      supabaseRefreshToken: 'stale-refresh-token',
+      supabaseTokenExpiry: Date.now() - 60_000,
+      refreshTokenIssuedAt: Date.now() - 31 * 24 * 60 * 60 * 1000,
+    };
+    vi.mocked(chrome.storage.local.get).mockImplementation(async (keys) => {
+      const requestedKeys = Array.isArray(keys) ? keys : [keys];
+      return Object.fromEntries(
+        requestedKeys
+          .filter((key): key is string => typeof key === 'string' && key in storedSession)
+          .map((key) => [key, storedSession[key]])
+      );
+    });
+    vi.mocked(chrome.storage.local.remove).mockImplementation(async (keys) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        delete storedSession[key];
+      }
+    });
+
+    authService = SupabaseAuthService.getInstance();
+
+    await authService.forceCheck();
+
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: 'https://bolt2github.com/login',
+      active: true,
+    });
+    expect(authService.getAuthState()).toMatchObject({
+      isAuthenticated: false,
+      user: null,
+      subscription: { isActive: false, plan: 'free' },
+    });
+  });
+
+  test('opens only one recovery tab when stored-session checks overlap', async () => {
+    const storedSession: Record<string, unknown> = {
+      supabaseToken: 'expired-access-token',
+      supabaseRefreshToken: 'stale-refresh-token',
+      supabaseTokenExpiry: Date.now() - 60_000,
+      refreshTokenIssuedAt: Date.now() - 31 * 24 * 60 * 60 * 1000,
+    };
+    vi.mocked(chrome.storage.local.get).mockImplementation(async (keys) => {
+      const requestedKeys = Array.isArray(keys) ? keys : [keys];
+      return Object.fromEntries(
+        requestedKeys
+          .filter((key): key is string => typeof key === 'string' && key in storedSession)
+          .map((key) => [key, storedSession[key]])
+      );
+    });
+    vi.mocked(chrome.storage.local.remove).mockImplementation(async (keys) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        delete storedSession[key];
+      }
+    });
+
+    authService = SupabaseAuthService.getInstance();
+
+    await Promise.all([authService.forceCheck(), authService.forceCheck()]);
+
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(1);
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: 'https://bolt2github.com/login',
+      active: true,
+    });
+  });
 });

--- a/src/lib/constants/__tests__/whatsNewContent.test.ts
+++ b/src/lib/constants/__tests__/whatsNewContent.test.ts
@@ -5,6 +5,49 @@ import { describe, expect, it } from 'vitest';
 import { whatsNewContent, type WhatsNewVersion } from '../whatsNewContent';
 
 describe('whatsNewContent', () => {
+  it('keeps package and Chrome manifest versions aligned for 1.3.21', () => {
+    const PackageVersion_1_3_21 = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+    ) as { version: string };
+    const ChromeManifestVersion_1_3_21 = JSON.parse(
+      readFileSync(join(process.cwd(), 'manifest.json'), 'utf8')
+    ) as { version: string };
+    const DevelopmentGuideVersion_1_3_21 = readFileSync(join(process.cwd(), 'CLAUDE.md'), 'utf8');
+
+    expect(PackageVersion_1_3_21.version).toBe('1.3.21');
+    expect(ChromeManifestVersion_1_3_21.version).toBe('1.3.21');
+    expect(DevelopmentGuideVersion_1_3_21).toContain('**Current Version**: v1.3.21');
+  });
+
+  it('keeps the v1.3.21 release surfaces final and user-facing', () => {
+    const release: WhatsNewVersion = whatsNewContent['1.3.21'];
+    const releaseText = [release.details, ...release.highlights].join(' ');
+    const Version_1_3_21_Changelog = readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf8');
+    const Version_1_3_21_Readme = readFileSync(join(process.cwd(), 'README.md'), 'utf8');
+
+    expect(release.date).toBe('2026-07-13');
+    expect(release.type).toBe('patch');
+    expect(release.highlights).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('First Install'),
+        expect.stringContaining('Login Tabs'),
+        expect.stringContaining('Recovery Preserved'),
+        expect.stringContaining('GitHub App Retry Loop'),
+        expect.stringContaining('Stable Background Checks'),
+        expect.stringContaining('Pro Follow-Up'),
+      ])
+    );
+    expect(releaseText).not.toMatch(/TBD|In Development|MAID|Vitest|Playwright/);
+
+    expect(Version_1_3_21_Changelog).toContain('## 2026-07-13 - Version 1.3.21');
+    expect(Version_1_3_21_Changelog).toContain('Fresh-Install Login Tab Fix');
+    expect(Version_1_3_21_Readme).toContain('### Latest Version: v1.3.21');
+    expect(Version_1_3_21_Readme).toContain(
+      '#### Version 1.3.21 - Cleaner First-Install Onboarding (July 2026)'
+    );
+    expect(Version_1_3_21_Readme).toContain('### Previous Version: v1.3.20');
+  });
+
   it('keeps the 1.3.20 modal focused on final user-facing release notes', () => {
     const release: WhatsNewVersion = whatsNewContent['1.3.20'];
     const releaseText = [release.details, ...release.highlights].join(' ');

--- a/src/lib/constants/whatsNewContent.ts
+++ b/src/lib/constants/whatsNewContent.ts
@@ -6,6 +6,19 @@ export interface WhatsNewVersion {
 }
 
 export const whatsNewContent: Record<string, WhatsNewVersion> = {
+  '1.3.21': {
+    date: '2026-07-13',
+    highlights: [
+      '👋 Cleaner First Install - New installs now open only the welcome page',
+      '🚫 No Duplicate Login Tabs - Empty sessions no longer trigger automatic sign-in tabs',
+      '🔐 Recovery Preserved - Existing invalid sessions still guide you back to sign in',
+      '🛡️ GitHub App Retry Loop Fixed - Incomplete connections no longer trigger repeated background checks',
+      '⚙️ Stable Background Checks - Missing installation details no longer start repeated token checks',
+      '✨ Helpful Pro Follow-Up - Successful pushes can now show a lightweight Pro feature suggestion',
+    ],
+    details: `This cumulative Chrome Web Store release includes the v1.3.20 reliability improvements plus a cleaner first-install experience. New installs open only the welcome page instead of launching duplicate login tabs, while existing invalid sessions keep their guided recovery path. GitHub App checks no longer repeat endlessly when installation details are missing, open Bolt tabs receive clearer recovery guidance, and successful pushes may show a lightweight suggestion for a relevant Pro feature.`,
+    type: 'patch',
+  },
   '1.3.20': {
     date: '2026-07-12',
     highlights: [

--- a/src/test/e2e-helpers/popup-helpers.test.ts
+++ b/src/test/e2e-helpers/popup-helpers.test.ts
@@ -48,6 +48,30 @@ function createLocator(options: { visible?: boolean; text?: string } = {}): Loca
 }
 
 describe('popup E2E helper characterization', () => {
+  it('pins PAT onboarding validation to the current submit control', () => {
+    const authSpec = readFileSync(join(process.cwd(), 'e2e/auth.spec.ts'), 'utf8');
+
+    expect(authSpec).toContain("getByRole('button', { name: /get started|complete setup/i })");
+    expect(authSpec).not.toContain('button:has-text("Complete Setup")');
+  });
+
+  it('seeds product error flows through a live PAT connection', () => {
+    const errorFlowSpec = readFileSync(
+      join(process.cwd(), 'e2e/error-flow-product.spec.ts'),
+      'utf8'
+    );
+    const seedProductAuth = errorFlowSpec.slice(
+      errorFlowSpec.indexOf('async function seedProductAuth'),
+      errorFlowSpec.indexOf('async function dismissWhatsNewForCurrentVersion')
+    );
+
+    expect(seedProductAuth).toContain("authenticationMethod: 'pat'");
+    expect(seedProductAuth).toContain("githubToken: 'ghp_e2e_product_token'");
+    expect(seedProductAuth).not.toContain("authenticationMethod: 'github_app'");
+    expect(seedProductAuth).not.toContain('githubAppInstallationId');
+    expect(errorFlowSpec).toContain("context.route('https://api.github.com/users/testuser'");
+  });
+
   it('pins lifecycle E2E to current storage keys and popup URL', () => {
     const lifecycleSpec = readFileSync(join(process.cwd(), 'e2e/lifecycle.spec.ts'), 'utf8');
 


### PR DESCRIPTION
## Summary

- prepare the v1.3.21 package, Chrome manifest, README, changelog, and development-guide versions
- publish cumulative in-app notes containing the unsubmitted v1.3.20 changes plus the fresh-install correction
- preserve guided recovery for failed stored sessions while deduplicating overlapping MV3 recovery checks
- align browser fixtures with the live GitHub connection gate

## Why

Version 1.3.20 was published on GitHub but not submitted to the Chrome Web Store. Version 1.3.21 is the immutable follow-up that CWS users will receive, so its in-app notes include both releases.

## Validation

- 4,364 Vitest tests passed across 195 files
- Playwright: 59 passed, 3 intentionally skipped
- production build, lint, and type checking passed
- MAID verify: all 9 gates passed
- independent implementation review: Ready to merge